### PR TITLE
Fix recent API key activity reporting

### DIFF
--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -374,7 +375,9 @@ func (s *Server) evaluateResponse(ctx context.Context, keyID, accountID string, 
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if s.activity.ShouldRecord(accountID, keyID, s.now()) {
-			_ = s.store.RecordRequestSuccess(ctx, accountID, keyID, s.now())
+			if err := s.store.RecordRequestSuccess(ctx, accountID, keyID, s.now()); err != nil {
+				slog.Error("request activity update failed", "account_id", accountID, "api_key_id", keyID, "error", err)
+			}
 		}
 	}
 	if resp.StatusCode >= 500 {

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -112,20 +112,37 @@ func TestPostgresAssignmentAndUsage(t *testing.T) {
 	if err = database.AddPoolAccount(ctx, domain.PoolAccount{PoolID: pool.ID, ProviderAccountID: account.ID, Weight: 1, Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
+	assertUsageActivity(t, ctx, database, account, keys[2])
+}
+
+func assertUsageActivity(t *testing.T, ctx context.Context, database *Postgres, account domain.ProviderAccount, key domain.APIKey) {
+	t.Helper()
 	day := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	firstUsageEvent := bytes.Repeat([]byte{10}, 32)
-	if err = database.AddUsage(ctx, keys[2].ID, firstUsageEvent, "test-model", day, 10, 4); err != nil {
+	if err := database.AddUsage(ctx, key.ID, firstUsageEvent, "test-model", day, 10, 4); err != nil {
 		t.Fatal(err)
 	}
-	if err = database.AddUsage(ctx, keys[2].ID, firstUsageEvent, "test-model", day, 10, 4); err != nil {
+	if err := database.AddUsage(ctx, key.ID, firstUsageEvent, "test-model", day, 10, 4); err != nil {
 		t.Fatal(err)
 	}
-	if err = database.AddUsage(ctx, keys[2].ID, bytes.Repeat([]byte{11}, 32), "test-model", day, 2, 1); err != nil {
+	if err := database.AddUsage(ctx, key.ID, bytes.Repeat([]byte{11}, 32), "test-model", day, 2, 1); err != nil {
 		t.Fatal(err)
 	}
-	rows, err := database.ListUsage(ctx, domain.UsageFilter{APIKeyID: keys[2].ID})
+	rows, err := database.ListUsage(ctx, domain.UsageFilter{APIKeyID: key.ID})
 	if err != nil || len(rows) != 1 || rows[0].InputTokens != 12 || rows[0].OutputTokens != 5 {
 		t.Fatalf("usage = %#v, %v", rows, err)
+	}
+	listedKeys, err := database.ListAPIKeys(ctx)
+	if err != nil || len(listedKeys) == 0 || listedKeys[0].ID != key.ID || listedKeys[0].LastUsedAt == nil || !listedKeys[0].LastUsedAt.Equal(day) {
+		t.Fatalf("API keys with activity = %#v, %v", listedKeys, err)
+	}
+	requestAt := day.Add(time.Hour)
+	if err = database.RecordRequestSuccess(ctx, account.ID, key.ID, requestAt); err != nil {
+		t.Fatal(err)
+	}
+	listedKeys, err = database.ListAPIKeys(ctx)
+	if err != nil || listedKeys[0].LastUsedAt == nil || !listedKeys[0].LastUsedAt.Equal(requestAt) {
+		t.Fatalf("API key last used = %#v, %v", listedKeys, err)
 	}
 }
 

--- a/internal/store/routing.go
+++ b/internal/store/routing.go
@@ -162,7 +162,8 @@ func selectAccountForUpdate(ctx context.Context, tx pgx.Tx, poolID string, exclu
 
 func (p *Postgres) ListAPIKeys(ctx context.Context) ([]domain.APIKey, error) {
 	rows, err := p.pool.Query(ctx, `SELECT k.id,k.pool_id,COALESCE(b.provider_account_id::text,''),k.employee_name,k.key_hint,k.scopes,k.rate_limit,k.expires_at,k.revoked_at,k.last_used_at,k.created_at
-		FROM api_keys k LEFT JOIN api_key_account_bindings b ON b.api_key_id=k.id ORDER BY k.created_at DESC`)
+		FROM api_keys k LEFT JOIN api_key_account_bindings b ON b.api_key_id=k.id
+		ORDER BY k.last_used_at DESC NULLS LAST,k.created_at DESC`)
 	if err != nil {
 		return nil, wrapDB("list API keys", err)
 	}
@@ -251,7 +252,7 @@ func (p *Postgres) RecordRequestSuccess(ctx context.Context, accountID, keyID st
 	_, err := p.pool.Exec(ctx, `WITH account AS (
 		UPDATE provider_accounts SET status='active',cooldown_until=NULL,last_success_at=$3,
 			health_status='healthy',last_checked_at=$3,last_health_error_code=NULL,consecutive_health_failures=0,
-			next_health_check_at=$3+interval '5 minutes',updated_at=now() WHERE id=$1 RETURNING id
+		next_health_check_at=$3::timestamptz+interval '5 minutes',updated_at=now() WHERE id=$1 RETURNING id
 	) UPDATE api_keys SET last_used_at=$3 WHERE id=$2 AND EXISTS(SELECT 1 FROM account)`, accountID, keyID, occurredAt)
 	return wrapDB("record request success", err)
 }
@@ -288,6 +289,10 @@ func (p *Postgres) AddUsage(ctx context.Context, keyID string, eventHash []byte,
 		output_tokens=api_key_usage_daily.output_tokens+excluded.output_tokens,updated_at=now()`, keyID, day.UTC(), model, input, output)
 	if err != nil {
 		return wrapDB("add usage", err)
+	}
+	_, err = tx.Exec(ctx, `UPDATE api_keys SET last_used_at=GREATEST(COALESCE(last_used_at,$2),$2) WHERE id=$1`, keyID, day.UTC())
+	if err != nil {
+		return wrapDB("update API key activity", err)
 	}
 	if err = tx.Commit(ctx); err != nil {
 		return wrapDB("commit usage transaction", err)

--- a/migrations/014_api_key_activity.sql
+++ b/migrations/014_api_key_activity.sql
@@ -1,0 +1,12 @@
+UPDATE api_keys k
+SET last_used_at = usage.last_used_at
+FROM (
+    SELECT api_key_id, MAX(updated_at) AS last_used_at
+    FROM api_key_usage_daily
+    GROUP BY api_key_id
+) usage
+WHERE k.id = usage.api_key_id
+  AND (k.last_used_at IS NULL OR k.last_used_at < usage.last_used_at);
+
+CREATE INDEX IF NOT EXISTS api_keys_last_used_at_idx
+    ON api_keys(last_used_at DESC NULLS LAST, created_at DESC);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import { AccountsPage } from './pages/AccountsPage'
 import { APIKeysPage } from './pages/APIKeysPage'
+import { OverviewPage } from './pages/OverviewPage'
 import { PoolsPage } from './pages/PoolsPage'
 import { UsagePage } from './pages/UsagePage'
 import { SettingsPage } from './pages/SettingsPage'
@@ -356,6 +357,21 @@ describe('Subpool console', () => {
     expect(screen.getAllByText('500,000').length).toBeGreaterThan(0)
     expect(screen.getAllByText('2.50M').length).toBeGreaterThan(0)
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([path]) => String(path).startsWith('/api/v1/usage?from='))).toBe(true))
+  })
+
+  it('shows usage totals in recent key activity', async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const path = String(input)
+      if (path === '/api/v1/provider-accounts') return json({ data: [{ id: 'account-1', display_name: 'Example account', provider: 'codex', status: 'active' }] })
+      if (path === '/api/v1/pools') return json({ data: [{ id: 'pool-1', name: 'Example pool', provider: 'codex' }] })
+      if (path === '/api/v1/api-keys') return json({ data: [{ id: 'key-1', pool_id: 'pool-1', provider_account_id: 'account-1', employee_name: 'Example employee', key_hint: '1234', created_at: '2026-09-01T00:00:00Z', last_used_at: '2026-09-02T00:00:00Z' }] })
+      if (path === '/api/v1/usage') return json({ data: [{ api_key_id: 'key-1', employee_name: 'Example employee', key_hint: '1234', model: 'example-model', usage_date: '2026-09-02', input_tokens: 1_200, output_tokens: 300 }] })
+      throw new Error(`Unexpected request: ${path}`)
+    })
+
+    render(<OverviewPage />)
+
+    expect(await screen.findByRole('row', { name: /Example employee.*1\.2K.*300/i })).toBeInTheDocument()
   })
 
   it('updates the employee key capacity setting', async () => {

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -59,17 +59,19 @@ function UsagePanel({ items, error, onReload }: { items: UsageRecord[]; error: s
   </section>
 }
 
-function RecentKeysPanel({ accounts, keys, pools, error, onReload }: { accounts: ProviderAccount[]; keys: APIKeyRecord[]; pools: Pool[]; error: string; onReload: () => void }) {
+function RecentKeysPanel({ accounts, keys, pools, usageByKey, error, onReload }: { accounts: ProviderAccount[]; keys: APIKeyRecord[]; pools: Pool[]; usageByKey: Map<string, UsageRecord>; error: string; onReload: () => void }) {
   return <section className="overview-panel overview-panel--table" aria-labelledby="recent-keys-heading">
     <header><div><h3 id="recent-keys-heading">Recent key activity</h3><p>Usage totals only; request content is never stored</p></div><a href="#/api-keys">Manage keys</a></header>
     {error ? <StatePanel kind="error" title="API keys unavailable" description={error} actionLabel="Try again" onAction={onReload} /> : keys.length === 0 ? <StatePanel kind="empty" title="No API keys issued" description="Create an employee key after a routing pool is ready." /> : <div className="table-frame"><table><thead><tr><th>Employee</th><th>Pool</th><th>Bound account</th><th className="number">Input</th><th className="number">Output</th><th>Last used</th></tr></thead><tbody>
-      {keys.slice(0, 5).map((key) => <tr key={key.id}>
+      {keys.slice(0, 5).map((key) => {
+        const usage = usageByKey.get(key.id)
+        return <tr key={key.id}>
         <td data-label="Employee"><strong>{key.employee_name}</strong><small><code>••••{key.key_hint}</code></small></td>
         <td data-label="Pool">{key.pool_name ?? pools.find((pool) => pool.id === key.pool_id)?.name ?? key.pool_id}</td>
         <td data-label="Bound account">{accounts.find((account) => account.id === key.provider_account_id)?.display_name ?? 'Pending assignment'}</td>
-        <td data-label="Input" className="number">{compact(key.input_tokens ?? 0)}</td><td data-label="Output" className="number">{compact(key.output_tokens ?? 0)}</td>
+        <td data-label="Input" className="number">{compact(usage?.input_tokens ?? 0)}</td><td data-label="Output" className="number">{compact(usage?.output_tokens ?? 0)}</td>
         <td data-label="Last used">{relativeTime(key.last_used_at)}</td>
-      </tr>)}
+      </tr>})}
     </tbody></table></div>}
   </section>
 }
@@ -96,10 +98,12 @@ export function OverviewPage() {
         result.set(item.api_key_id, { ...item })
       }
     }
-    return [...result.values()]
-      .sort((a, b) => b.input_tokens + b.output_tokens - a.input_tokens - a.output_tokens)
-      .slice(0, 5)
+    return result
   }, [usage.items])
+
+  const topUsage = useMemo(() => [...usageByKey.values()]
+    .sort((a, b) => b.input_tokens + b.output_tokens - a.input_tokens - a.output_tokens)
+    .slice(0, 5), [usageByKey])
 
   const activeKeys = keys.items.filter((key) => !key.revoked_at)
   const loading = accounts.loading || pools.loading || keys.loading || usage.loading
@@ -118,9 +122,9 @@ export function OverviewPage() {
           <OverviewMetrics accounts={accounts.items} pools={pools.items} keys={activeKeys} input={summary.input} output={summary.output} />
           <div className="overview-grid">
             <AssignmentsPanel accounts={accounts.items} error={accounts.error} onReload={() => void accounts.reload()} />
-            <UsagePanel items={usageByKey} error={usage.error} onReload={() => void usage.reload()} />
+            <UsagePanel items={topUsage} error={usage.error} onReload={() => void usage.reload()} />
           </div>
-          <RecentKeysPanel accounts={accounts.items} keys={activeKeys} pools={pools.items} error={keys.error} onReload={() => void keys.reload()} />
+          <RecentKeysPanel accounts={accounts.items} keys={activeKeys} pools={pools.items} usageByKey={usageByKey} error={keys.error} onReload={() => void keys.reload()} />
         </>
       )}
     </section>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -104,8 +104,6 @@ export interface APIKeyRecord {
   revoked_at?: string | null
   last_used_at?: string | null
   created_at: string
-  input_tokens?: number
-  output_tokens?: number
 }
 
 export interface UsageRecord {


### PR DESCRIPTION
## Summary

- fix PostgreSQL timestamp typing so successful request activity is persisted
- update API key activity atomically with usage and backfill historical activity timestamps
- order API keys by recent activity and reuse the existing usage response for Overview totals
- log activity update failures and cover the corrected UI and store behavior

## Testing

- `make test build`
