### PR TITLE
Add ECR image and deployment pipelines

### DIFF
--- a/.github/workflows/deploy-pre.yml
+++ b/.github/workflows/deploy-pre.yml
@@ -2,24 +2,29 @@ name: Deploy Subpool to Gesta Pre
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git branch, tag, or commit to deploy
+        required: true
+        default: main
+        type: string
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: subpool-pre-deploy
   cancel-in-progress: false
 
 env:
-  AWS_REGION: us-east-2
+  AWS_REGION: ${{ vars.SUBPOOL_DEPLOY_AWS_REGION || 'us-east-2' }}
   GESTA_PRE_INSTANCE_ID: i-06dd31f05e6c295fd
   SUBPOOL_HOST_PORT: "8082"
   SUBPOOL_PUBLIC_URL: http://3.21.189.90:8082
 
 jobs:
   deploy:
-    name: Build and deploy
+    name: Deploy selected Subpool revision
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: preproduction
@@ -45,27 +50,19 @@ jobs:
             test -n "${!name:-}" || { echo "$name is required" >&2; exit 1; }
           done
 
-      - name: Check out source
+      - name: Check out selected revision
         uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          ref: ${{ inputs.ref }}
 
-      - name: Build and publish image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Resolve deployment image
+        id: image
+        run: |
+          revision="$(git rev-parse HEAD)"
+          {
+            echo "sha=$revision"
+            echo "uri=public.ecr.aws/cloudpilotai/subpool:sha-$revision"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -74,16 +71,29 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SK }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Log in to ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Verify deployment image
+        env:
+          SUBPOOL_IMAGE: ${{ steps.image.outputs.uri }}
+        run: |
+          if ! docker manifest inspect "$SUBPOOL_IMAGE" >/dev/null 2>&1; then
+            echo "$SUBPOOL_IMAGE is not published; deploy only completed image revisions" >&2
+            exit 1
+          fi
+
       - name: Deploy with AWS Systems Manager
         env:
-          SUBPOOL_IMAGE: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          SUBPOOL_IMAGE: ${{ steps.image.outputs.uri }}
+          SUBPOOL_DEPLOY_SHA: ${{ steps.image.outputs.sha }}
           SUBPOOL_ADMIN_USERNAME: ${{ secrets.SUBPOOL_ADMIN_USERNAME }}
           SUBPOOL_ADMIN_PASSWORD: ${{ secrets.SUBPOOL_ADMIN_PASSWORD }}
           SUBPOOL_POSTGRES_PASSWORD: ${{ secrets.SUBPOOL_POSTGRES_PASSWORD }}
           SUBPOOL_CREDENTIAL_KEY: ${{ secrets.SUBPOOL_CREDENTIAL_KEY }}
           SUBPOOL_API_KEY_HMAC_KEY: ${{ secrets.SUBPOOL_API_KEY_HMAC_KEY }}
-          GHCR_TOKEN: ${{ github.token }}
-          GHCR_USERNAME: ${{ github.actor }}
         run: |
           set -euo pipefail
 
@@ -107,20 +117,16 @@ jobs:
             "SUBPOOL_CREDENTIAL_KEY=$SUBPOOL_CREDENTIAL_KEY" \
             "SUBPOOL_API_KEY_HMAC_KEY=$SUBPOOL_API_KEY_HMAC_KEY" \
             | base64 | tr -d '\n')"
-          token_b64="$(printf '%s' "$GHCR_TOKEN" | base64 | tr -d '\n')"
-
           remote_script="$(cat <<SCRIPT
           set -euo pipefail
           install -d -m 700 /gesta/subpool
           printf '%s' '$compose_b64' | base64 -d > /gesta/subpool/compose.yaml
           printf '%s' '$environment_b64' | base64 -d > /gesta/subpool/.env
           chmod 600 /gesta/subpool/.env
-          printf '%s' '$token_b64' | base64 -d | docker login ghcr.io --username '$GHCR_USERNAME' --password-stdin
           cd /gesta/subpool
           docker compose --env-file .env pull
           docker compose --env-file .env up -d --remove-orphans
-          docker logout ghcr.io >/dev/null 2>&1 || true
-          for attempt in \$(seq 1 30); do
+          for _ in \$(seq 1 30); do
             if curl -fsS 'http://127.0.0.1:$SUBPOOL_HOST_PORT/healthz' >/dev/null; then
               exit 0
             fi
@@ -136,14 +142,14 @@ jobs:
           command_id="$(aws ssm send-command \
             --instance-ids "$GESTA_PRE_INSTANCE_ID" \
             --document-name AWS-RunShellScript \
-            --comment "Deploy Subpool ${GITHUB_SHA}" \
+            --comment "Deploy Subpool $SUBPOOL_DEPLOY_SHA" \
             --parameters "$parameters" \
             --query 'Command.CommandId' \
             --output text)"
           echo "SSM command id: $command_id"
 
           final_status=""
-          for attempt in $(seq 1 120); do
+          for _ in $(seq 1 120); do
             final_status="$(aws ssm get-command-invocation \
               --command-id "$command_id" \
               --instance-id "$GESTA_PRE_INSTANCE_ID" \

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,124 @@
+name: Build and Publish Subpool Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: subpool-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-test:
+    name: Test Go service
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Go tests
+        run: go test ./...
+
+  web-test:
+    name: Test and build web console
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Run web tests
+        working-directory: web
+        run: npm test
+
+      - name: Build web console
+        working-directory: web
+        run: npm run build
+
+  build:
+    name: Build Subpool image
+    needs:
+      - go-test
+      - web-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_AK }}
+          aws-secret-access-key: ${{ secrets.AWS_SK }}
+          aws-region: us-east-1
+
+      - name: Log in to ECR Public
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: public.ecr.aws/cloudpilotai/subpool
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=sha-${{ github.sha }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=subpool
+          cache-to: type=gha,scope=subpool,mode=max

--- a/docs/ci-cd-design.md
+++ b/docs/ci-cd-design.md
@@ -1,0 +1,133 @@
+# CI/CD Pipeline Design
+
+Status: Approved and implemented
+
+## Context
+
+Subpool currently has one manually triggered preproduction workflow. It builds
+an image, publishes an immutable `sha-<commit>` tag to GHCR, and deploys that
+image through AWS Systems Manager. Pull requests and main-branch changes do not
+have an automated validation pipeline. New images will move to the same ECR
+Public publishing model used by Gesta.
+
+## Goals
+
+- Give pull requests fast, deterministic Go and web validation.
+- Prove that the production Dockerfile builds before changes are merged.
+- Publish immutable commit images and readable release tags to ECR Public.
+- Keep preproduction deployment explicit and compatible with the existing
+  environment, secrets, image tags, and rollback process.
+- Keep workflow time and runner usage reasonable as the repository grows.
+
+## Non-goals
+
+- Automatic production deployment.
+- Kubernetes, Helm, or a new deployment platform.
+- Changing application runtime configuration or secret names.
+- Adding a new lint tool before the repository adopts one locally.
+
+## Proposed workflows
+
+### 1. `docker-image.yml`
+
+Triggers:
+
+- Pull requests targeting `main`.
+- Pushes to `main`.
+
+Validation jobs:
+
+1. `go-test`
+   - Use Go 1.24 with module caching.
+   - Run `go test ./...`.
+2. `web-test`
+   - Use Node.js 22 with npm cache keyed by `web/package-lock.json`.
+   - Run `npm ci`, `npm test`, and `npm run build` in `web`.
+3. `build`
+   - Depend on both test jobs.
+   - Build the production Dockerfile for `linux/amd64` without pushing on pull
+     requests.
+   - Build and publish `linux/amd64` and `linux/arm64` on trusted refs.
+   - Reuse the GitHub Actions BuildKit cache.
+
+Publishing behavior:
+
+- Build Linux `amd64` and `arm64` images with Buildx.
+- Push `sha-<commit>` for every run.
+- Also push `latest` and `main` for the default branch and the Git tag for
+  releases.
+- Attach OCI source and revision labels.
+- Authenticate with the existing AWS credentials and
+  `aws-actions/amazon-ecr-login`, matching Gesta's pipeline.
+- Publish to `public.ecr.aws/cloudpilotai/subpool`.
+- Use read-only GitHub permissions; ECR writes are authorized by AWS IAM.
+- Never publish an image when Go or web validation fails.
+
+The immutable SHA tag remains the deployment source of truth. Mutable tags are
+only discovery aliases and are not used for rollback decisions.
+
+Stale runs for the same pull request or branch are cancelled. Pull requests do
+not receive AWS credentials. Branch protection should require all three jobs.
+
+### 2. Existing `deploy-pre.yml`
+
+Keep `workflow_dispatch` and the `preproduction` environment. Refactor it to
+deploy a previously published immutable image instead of rebuilding source.
+The image is the selected Git ref's `sha-<commit>` tag, so the same ref input
+also supports rollback. Preserve the current secret names, remote Compose path,
+health check, and AWS Systems Manager transport.
+
+## Compatibility
+
+- Existing deployments remain manual.
+- Existing full `sha-<commit>` image tags continue to work; the default
+  registry changes from GHCR to ECR Public.
+- Existing GitHub environment and repository secrets are unchanged.
+- Go 1.24, Node.js 22, Docker Compose, and the current AWS deployment path
+  remain unchanged.
+- No application or database migration is introduced.
+
+## Performance and scale
+
+- Go modules, npm packages, and Docker layers use lockfile-aware caches.
+- Independent Go and web jobs run in parallel.
+- Superseded pull-request runs are cancelled.
+- Release images are built once and promoted by immutable digest or SHA tag;
+  deployments do not repeat the expensive multi-platform build.
+- If runner demand becomes material, path filtering may skip unrelated jobs,
+  but the Docker build remains a required merge check to prevent integration
+  drift.
+
+## Security
+
+- Pull-request CI receives no deployment secrets and cannot write packages.
+- Publishing occurs only from trusted repository refs.
+- Deployment secrets stay scoped to the protected `preproduction` environment.
+- Actions are pinned to stable major versions initially; commit-SHA pinning can
+  be adopted as a repository-wide hardening policy.
+
+## Rollout
+
+1. Add `docker-image.yml` and make its checks required.
+2. Verify an immutable ECR Public image from `main`.
+3. Refactor `deploy-pre.yml` to consume that image.
+4. Exercise a preproduction deploy and a rollback to an earlier SHA.
+
+## Acceptance criteria
+
+- A pull request runs Go tests, web tests/build, and a production image build.
+- A failing validation job prevents image publication.
+- Main and release refs produce the documented ECR Public tags for both target
+  architectures.
+- Preproduction deploys an existing immutable image without rebuilding it.
+- A previous immutable image can be selected for rollback.
+- No existing Subpool runtime configuration or deployment secret must change.
+
+## Review decision
+
+Approve or revise these defaults before implementation:
+
+- Preserve full compatibility with the current manual preproduction workflow.
+- Publish to ECR Public on `main` and version tags, without automatic
+  production deployment.
+- Support both `amd64` and `arm64` images.


### PR DESCRIPTION
## Summary

- add pull request, main, tag, and manual image validation workflows
- publish tested amd64 and arm64 images to ECR Public with immutable SHA tags
- deploy selected immutable ECR images through the existing manual preproduction workflow
- document compatibility, scaling, security, and rollback decisions

## Testing

- `make test`
- `make build`
- `actionlint .github/workflows/*.yml`
- `git diff --check`