### PR TITLE
Stabilize Codex device identity per account

### DIFF
--- a/docs/codex-account-device-identity-design.md
+++ b/docs/codex-account-device-identity-design.md
@@ -1,0 +1,196 @@
+# Codex Account Device Identity Design
+
+Status: Review draft
+
+## Context
+
+Different Codex clients can send different installation identifiers while
+sharing one Subpool-managed subscription account. Upstream can therefore see
+one account as many devices. Subpool should present one stable device identity
+for each Codex subscription account.
+
+This design only normalizes the Codex installation identifier. It is not TLS
+fingerprinting, browser emulation, or an attempt to bypass upstream controls.
+
+## Reference research
+
+The design was informed by [`Wei-Shaw/sub2api`](https://github.com/Wei-Shaw/sub2api)
+at commit `5097b31457e6dc9f49e5f5c9c72b925ce79543b3`. That project implements broader
+account-scoped fingerprint convergence and documents reports of changed quota
+behavior when it was enabled by default.
+
+Subpool intentionally adopts only the smallest useful part: a stable
+installation ID. Session, thread, turn, window, request, User-Agent, and
+transport behavior remain unchanged. Subpool will implement this independently
+without copying source code from the LGPL-licensed reference repository.
+
+## Goals
+
+- Give every Codex subscription account one stable installation ID.
+- Use the same ID in the direct header and supported metadata projections.
+- Keep the ID stable across API keys, processes, replicas, credential refreshes,
+  and restarts.
+- Recompute the ID for the selected account during retry or failover.
+- Require no administrator setting, mode, migration, cache, or background job.
+- Preserve existing API keys, client configuration, routing, and SSE behavior.
+
+## Non-goals
+
+- `off`, `balanced`, or other fingerprint modes.
+- Session, thread, turn, window, or request-ID convergence.
+- TLS, JA3, or JA4 fingerprint imitation.
+- User-Agent rotation or official-client impersonation.
+- WebSocket or Realtime API support.
+- Client detection, allowlists, or a configurable fingerprint rule engine.
+- A guarantee about upstream quota, priority, or risk decisions.
+
+## Product behavior
+
+The behavior is automatic and has no console control or public API field.
+Every request routed to a Codex subscription account uses that account's stable
+installation ID. Requests routed to OpenAI-compatible API-key accounts are not
+changed.
+
+Deployment changes the installation ID seen by upstream for existing accounts
+on their next request. Client-visible session, thread, turn, window, and
+response identifiers remain unchanged. Removing the feature requires a normal
+application rollback; there is no runtime mode switch in the first version.
+
+## Identity derivation
+
+`provider_accounts.id` is already a persistent random UUID and is available on
+every routing attempt. Subpool derives the installation ID as follows:
+
+1. Hash the versioned domain label
+   `subpool/codex/installation-id/v1` and the provider account ID with SHA-256.
+2. Use the first 16 digest bytes.
+3. Set the RFC 4122 variant and UUIDv4 version bits.
+4. Format the result as a canonical lowercase UUID.
+
+The domain label prevents accidental reuse for a future identity type. Hashing
+avoids sending Subpool's internal account ID to upstream. The account ID has
+enough random entropy, so no additional seed or database column is required.
+
+Consequences:
+
+- All employee API keys routed to the same account share one installation ID.
+- Different provider accounts receive different installation IDs.
+- Credential refresh and service restart do not change the ID.
+- Deleting and recreating an account creates a new ID.
+- Failover to another account intentionally changes the ID to that account's
+  value.
+
+The derived identifier is internal operational metadata. It must not be exposed
+through the control API or included in logs and audit events.
+
+## Request transformation
+
+Transformation happens after account selection and immediately before building
+the upstream Codex request. Each retry derives and applies the identity for its
+selected account; the downstream request and shared headers remain immutable.
+
+Subpool rewrites only these installation fields:
+
+- HTTP header `X-Codex-Installation-Id` is always set to the derived ID.
+- Body `client_metadata["x-codex-installation-id"]` is set to the same ID.
+- If `X-Codex-Turn-Metadata` is present as a valid JSON object, its
+  `installation_id` field is replaced with the same ID.
+- If `client_metadata["x-codex-turn-metadata"]` is present as a valid JSON
+  object encoded as a string, its `installation_id` field is replaced with the
+  same ID.
+
+An absent `client_metadata` object is created. A present non-object
+`client_metadata` value is rejected as an invalid request because it cannot be
+updated without discarding client data. Absent turn metadata is not created.
+Malformed optional turn metadata is preserved; the canonical direct header and
+body field remain authoritative.
+
+All unrelated fields are preserved. In particular, Subpool does not rewrite
+`Session-Id`, `Thread-Id`, `X-Codex-Window-Id`, `X-Client-Request-Id`,
+`prompt_cache_key`, or their body equivalents.
+
+The existing Codex request-normalization pass should apply streaming rules and
+the device identity in one body decode. It runs per upstream attempt because
+failover can select a different account. No recursive copy of prompt or tool
+payloads is needed.
+
+## Code structure
+
+- `internal/provider/codex/device_identity.go`: deterministic installation-ID
+  derivation and targeted metadata rewriting.
+- `internal/gateway`: pass the selected provider account ID into each Codex
+  attempt and map invalid metadata to the existing invalid-request response.
+- `internal/provider/codex/client.go`: set the canonical installation header on
+  the outbound request.
+
+No domain-model, store, migration, control API, or web-console change is
+required.
+
+## Compatibility and rollout
+
+- Existing API keys, provider credentials, pool bindings, routing decisions,
+  session bindings, response IDs, SSE framing, and error codes are unchanged.
+- Existing Codex account rows require no backfill.
+- The only intentional behavior change is that client-supplied installation IDs
+  are replaced by one stable value per selected account.
+- OpenAI-compatible accounts and non-Codex upstream requests are unchanged.
+- Rollback restores the current pass-through behavior without a data migration.
+
+Roll out the application normally, then observe existing account-health,
+upstream-error, and quota signals. Do not add fingerprint-specific analytics or
+log identifiers in the first version.
+
+## Failure behavior
+
+- Derivation has no I/O and cannot lose persisted state.
+- An empty provider account ID is an internal configuration error;
+  fail before contacting upstream.
+- A non-object `client_metadata` value returns the existing invalid-request
+  response.
+- Retry with refreshed credentials keeps the same installation ID.
+- Failover recomputes the ID for the newly selected account.
+- Errors never include client-supplied or derived identifiers.
+
+## Verification
+
+- Unit tests cover deterministic derivation, account separation, UUID format,
+  and domain versioning.
+- Transformation tests cover the header, flat body metadata, nested turn
+  metadata, absent metadata, malformed optional metadata, preservation of
+  unrelated fields, and rejection of non-object `client_metadata`.
+- Gateway tests cover credential refresh stability and account failover.
+- Regression tests prove session, thread, turn, window, request, cache, and SSE
+  behavior are unchanged.
+
+## Senior architect and product review
+
+### High-confidence problems and risks
+
+- Upstream policy is opaque. Stable device identity must not be presented as a
+  quota improvement or risk-control bypass.
+- Existing accounts change device identity immediately after deployment. With
+  no runtime switch, rollback is the only fast escape if upstream behavior
+  regresses.
+- Header and body projections can diverge if rewritten in separate paths. One
+  derived value must be passed through the entire attempt.
+- Failover must not reuse the failed account's ID.
+- Malformed metadata needs explicit behavior; silently replacing the whole
+  object could delete client data.
+
+### Over-engineering to avoid
+
+- A mode column, per-account setting, seed column, migration, admin UI, session
+  table, cache, worker, and analytics are unnecessary for account-level device
+  stability.
+- Rewriting session, thread, turn, window, request, or cache identifiers expands
+  both compatibility risk and upstream uncertainty without serving this scope.
+- A generic fingerprint framework is premature; one small Codex-specific
+  transformer is sufficient.
+
+### Smaller version assessment
+
+This is the smaller viable version: derive one installation ID from the
+existing provider account ID and rewrite only installation fields. Removing
+metadata consistency would be smaller in code but could send contradictory
+device identities, so it is not recommended. No additional product mode or
+storage is justified.

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -36,6 +36,7 @@ const (
 	retryAuth        retryReason = "authentication"
 	retryRefresh     retryReason = "refresh"
 	retryRateLimit   retryReason = "rate_limit"
+	retryInvalid     retryReason = "invalid_request"
 )
 
 type Cipher interface {
@@ -107,9 +108,8 @@ func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	codexBody := forceStream(body)
 	compatibleBody := forceProviderStream(body)
-	resp, ok := s.call(w, r, route, upstreamRequest{kind: "responses", body: compatibleBody, codexBody: codexBody}, meta.PreviousResponseID)
+	resp, ok := s.call(w, r, route, upstreamRequest{kind: "responses", body: compatibleBody, codexBody: body}, meta.PreviousResponseID)
 	if !ok {
 		return
 	}
@@ -222,10 +222,10 @@ func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, requestMeta, b
 	return body, meta, true
 }
 
-func forceStream(body []byte) []byte {
+func normalizeCodexRequest(body []byte, installationID string) ([]byte, error) {
 	var value map[string]any
-	if json.Unmarshal(body, &value) != nil {
-		return body
+	if err := json.Unmarshal(body, &value); err != nil {
+		return nil, fmt.Errorf("decode Codex request: %w", err)
 	}
 	value["stream"] = true
 	value["store"] = false
@@ -244,11 +244,14 @@ func forceStream(body []byte) []byte {
 			}},
 		}}
 	}
+	if err := codex.ApplyDeviceIdentity(value, installationID); err != nil {
+		return nil, err
+	}
 	out, err := json.Marshal(value)
 	if err != nil {
-		return body
+		return nil, fmt.Errorf("encode Codex request: %w", err)
 	}
-	return out
+	return out, nil
 }
 
 func forceProviderStream(body []byte) []byte {
@@ -300,6 +303,10 @@ func (s *Server) call(w http.ResponseWriter, r *http.Request, route domain.KeyRo
 		if complete {
 			return resp, resp != nil
 		}
+		if retry == retryInvalid {
+			writeOpenAIError(w, http.StatusBadRequest, "client_metadata must be an object", "invalid_request_error")
+			return nil, false
+		}
 		lastRetry = retry
 		if continuation {
 			writeRetryFailure(w, lastRetry)
@@ -326,6 +333,9 @@ func (s *Server) attemptAccount(r *http.Request, route domain.KeyRoute, request 
 	}
 	resp, err := s.providerAccountResponse(r.Context(), request, r.Header, credentials, account)
 	if err != nil {
+		if errors.Is(err, codex.ErrInvalidClientMetadata) {
+			return nil, retryInvalid, false
+		}
 		s.recordHealthFailure(r.Context(), account.ID, "connection_failed")
 		return nil, retryUnavailable, false
 	}
@@ -355,6 +365,9 @@ func (s *Server) retryRefreshedAccount(r *http.Request, route domain.KeyRoute, r
 	}
 	resp, err := s.providerAccountResponse(r.Context(), request, r.Header, credentials, refreshed)
 	if err != nil {
+		if errors.Is(err, codex.ErrInvalidClientMetadata) {
+			return nil, retryInvalid, false
+		}
 		s.recordHealthFailure(r.Context(), refreshed.ID, "connection_failed")
 		return nil, retryUnavailable, false
 	}
@@ -476,7 +489,17 @@ func (s *Server) providerAccountResponse(ctx context.Context, request upstreamRe
 	)
 	switch account.Provider {
 	case "", domain.ProviderCodex:
-		resp, err = s.codex.Responses(ctx, request.codexBody, header, codexCredentials)
+		installationID, identityErr := codex.InstallationID(account.ID)
+		if identityErr != nil {
+			err = identityErr
+			break
+		}
+		codexBody, normalizeErr := normalizeCodexRequest(request.codexBody, installationID)
+		if normalizeErr != nil {
+			err = normalizeErr
+			break
+		}
+		resp, err = s.codex.Responses(ctx, codexBody, codex.DeviceIdentityHeaders(header, installationID), codexCredentials)
 		responseFormat = "responses"
 	case domain.ProviderOpenAICompatible:
 		if s.compatible == nil {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -115,6 +115,7 @@ type fakeProvider struct {
 	models      []codex.Model
 	credentials []codex.Credentials
 	bodies      [][]byte
+	headers     []http.Header
 }
 
 type fakeCompatibleProvider struct {
@@ -139,9 +140,10 @@ func (f *fakeCompatibleProvider) ChatCompletions(_ context.Context, body []byte,
 	return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"id":"chat-1","choices":[{"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}`))}, nil
 }
 
-func (f *fakeProvider) Responses(_ context.Context, body []byte, _ http.Header, credentials codex.Credentials) (*http.Response, error) {
+func (f *fakeProvider) Responses(_ context.Context, body []byte, headers http.Header, credentials codex.Credentials) (*http.Response, error) {
 	f.credentials = append(f.credentials, credentials)
 	f.bodies = append(f.bodies, append([]byte(nil), body...))
+	f.headers = append(f.headers, headers.Clone())
 	if len(f.errors) > 0 {
 		err := f.errors[0]
 		f.errors = f.errors[1:]
@@ -190,6 +192,11 @@ func TestResponsesStreamMetersAndBindsSession(t *testing.T) {
 	if upstream["stream"] != true {
 		t.Fatal("upstream request did not force streaming")
 	}
+	wantInstallationID, _ := codex.InstallationID("account-1")
+	metadata, _ := upstream["client_metadata"].(map[string]any)
+	if provider.headers[0].Get("X-Codex-Installation-Id") != wantInstallationID || metadata["x-codex-installation-id"] != wantInstallationID {
+		t.Fatalf("headers=%#v metadata=%#v", provider.headers[0], metadata)
+	}
 }
 
 func TestOpenAICompatibleChatPassesThroughAndMetersUsage(t *testing.T) {
@@ -224,8 +231,11 @@ func TestOpenAICompatibleChatPassesThroughAndMetersUsage(t *testing.T) {
 	}
 }
 
-func TestForceStreamConvertsStringInputForCodexBackend(t *testing.T) {
-	body := forceStream([]byte(`{"model":"gpt-5.6-sol","input":"Reply with OK"}`))
+func TestNormalizeCodexRequestConvertsStringInput(t *testing.T) {
+	body, err := normalizeCodexRequest([]byte(`{"model":"gpt-5.6-sol","input":"Reply with OK"}`), "11111111-1111-4111-8111-111111111111")
+	if err != nil {
+		t.Fatal(err)
+	}
 	var request struct {
 		Stream bool `json:"stream"`
 		Store  bool `json:"store"`
@@ -242,6 +252,17 @@ func TestForceStreamConvertsStringInputForCodexBackend(t *testing.T) {
 	}
 	if !request.Stream || request.Store || len(request.Input) != 1 || request.Input[0].Role != "user" || len(request.Input[0].Content) != 1 || request.Input[0].Content[0].Type != "input_text" || request.Input[0].Content[0].Text != "Reply with OK" {
 		t.Fatalf("normalized request = %#v", request)
+	}
+}
+
+func TestResponsesRejectsNonObjectClientMetadata(t *testing.T) {
+	server, _, provider, plain := newTestServer(t)
+	recorder := serveGateway(t, server, plain, "/v1/responses", `{"model":"gpt-test","input":"hello","client_metadata":"invalid"}`)
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), "invalid_request_error") {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if len(provider.credentials) != 0 {
+		t.Fatal("provider was called")
 	}
 }
 
@@ -289,6 +310,21 @@ func TestRateLimitedAccountReassignsBeforeStreaming(t *testing.T) {
 	}
 	if len(provider.credentials) != 2 || provider.credentials[1].AccessToken != "token-2" {
 		t.Fatalf("credentials = %#v", provider.credentials)
+	}
+	firstID, _ := codex.InstallationID("account-1")
+	secondID, _ := codex.InstallationID("account-2")
+	if len(provider.headers) != 2 || provider.headers[0].Get("X-Codex-Installation-Id") != firstID || provider.headers[1].Get("X-Codex-Installation-Id") != secondID || firstID == secondID {
+		t.Fatalf("installation IDs were not rebound on failover")
+	}
+	for index, want := range []string{firstID, secondID} {
+		var request map[string]any
+		if err := json.Unmarshal(provider.bodies[index], &request); err != nil {
+			t.Fatal(err)
+		}
+		metadata, _ := request["client_metadata"].(map[string]any)
+		if metadata["x-codex-installation-id"] != want {
+			t.Fatalf("attempt %d body installation ID = %v, want %q", index, metadata["x-codex-installation-id"], want)
+		}
 	}
 	if len(st.status) == 0 || st.status[0] != domain.AccountCoolingDown {
 		t.Fatalf("statuses = %#v", st.status)

--- a/internal/provider/codex/client.go
+++ b/internal/provider/codex/client.go
@@ -68,7 +68,7 @@ func (c *Client) Responses(ctx context.Context, body []byte, downstream http.Hea
 	if credentials.AccountID != "" {
 		req.Header.Set("Chatgpt-Account-Id", credentials.AccountID)
 	}
-	for _, name := range []string{"Version", "X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "X-Client-Request-Id", "X-Codex-Window-Id", "Thread-Id", "Session-Id", "X-Openai-Internal-Codex-Responses-Lite"} {
+	for _, name := range []string{"Version", "X-Codex-Beta-Features", "X-Codex-Installation-Id", "X-Codex-Turn-Metadata", "X-Client-Request-Id", "X-Codex-Window-Id", "Thread-Id", "Session-Id", "X-Openai-Internal-Codex-Responses-Lite"} {
 		if value := downstream.Get(name); value != "" {
 			req.Header.Set(name, value)
 		}

--- a/internal/provider/codex/client_test.go
+++ b/internal/provider/codex/client_test.go
@@ -14,7 +14,7 @@ func TestClientResponses(t *testing.T) {
 		if r.URL.Path != "/responses" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
-		for name, want := range map[string]string{"Authorization": "Bearer access", "Chatgpt-Account-Id": "acct", "Originator": "codex_cli_rs", "Accept": "text/event-stream", "Session-Id": "session"} {
+		for name, want := range map[string]string{"Authorization": "Bearer access", "Chatgpt-Account-Id": "acct", "Originator": "codex_cli_rs", "Accept": "text/event-stream", "Session-Id": "session", "X-Codex-Installation-Id": "installation"} {
 			if got := r.Header.Get(name); got != want {
 				t.Errorf("%s = %q, want %q", name, got, want)
 			}
@@ -27,7 +27,7 @@ func TestClientResponses(t *testing.T) {
 	}))
 	defer server.Close()
 	client := NewClient(server.URL, http.DefaultClient)
-	headers := http.Header{"Session-Id": []string{"session"}}
+	headers := http.Header{"Session-Id": []string{"session"}, "X-Codex-Installation-Id": []string{"installation"}}
 	resp, err := client.Responses(context.Background(), []byte(`{"model":"gpt-test"}`), headers, Credentials{AccessToken: "access", AccountID: "acct"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/provider/codex/device_identity.go
+++ b/internal/provider/codex/device_identity.go
@@ -1,0 +1,85 @@
+package codex
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	installationIDDomain = "subpool/codex/installation-id/v1"
+	installationIDHeader = "X-Codex-Installation-Id"
+	turnMetadataHeader   = "X-Codex-Turn-Metadata"
+)
+
+var ErrInvalidClientMetadata = errors.New("client_metadata must be an object")
+
+func InstallationID(providerAccountID string) (string, error) {
+	if strings.TrimSpace(providerAccountID) == "" {
+		return "", errors.New("provider account ID is empty")
+	}
+	digest := sha256.Sum256([]byte(installationIDDomain + "\x00" + providerAccountID))
+	raw := digest[:16]
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", raw[0:4], raw[4:6], raw[6:8], raw[8:10], raw[10:16]), nil
+}
+
+func ApplyDeviceIdentity(body map[string]any, installationID string) error {
+	metadata, err := clientMetadata(body)
+	if err != nil {
+		return err
+	}
+	metadata[strings.ToLower(installationIDHeader)] = installationID
+	if raw, ok := metadata[strings.ToLower(turnMetadataHeader)].(string); ok {
+		if rewritten, valid := rewriteTurnMetadata(raw, installationID); valid {
+			metadata[strings.ToLower(turnMetadataHeader)] = rewritten
+		}
+	}
+	return nil
+}
+
+func DeviceIdentityHeaders(source http.Header, installationID string) http.Header {
+	headers := source.Clone()
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	headers.Set(installationIDHeader, installationID)
+	if raw := headers.Get(turnMetadataHeader); raw != "" {
+		if rewritten, valid := rewriteTurnMetadata(raw, installationID); valid {
+			headers.Set(turnMetadataHeader, rewritten)
+		}
+	}
+	return headers
+}
+
+func clientMetadata(body map[string]any) (map[string]any, error) {
+	raw, exists := body["client_metadata"]
+	if !exists || raw == nil {
+		metadata := make(map[string]any)
+		body["client_metadata"] = metadata
+		return metadata, nil
+	}
+	metadata, ok := raw.(map[string]any)
+	if !ok {
+		return nil, ErrInvalidClientMetadata
+	}
+	return metadata, nil
+}
+
+func rewriteTurnMetadata(raw, installationID string) (string, bool) {
+	var metadata map[string]json.RawMessage
+	if json.Unmarshal([]byte(raw), &metadata) != nil || metadata == nil {
+		return "", false
+	}
+	encodedID, _ := json.Marshal(installationID)
+	metadata["installation_id"] = encodedID
+	rewritten, err := json.Marshal(metadata)
+	if err != nil {
+		return "", false
+	}
+	return string(rewritten), true
+}

--- a/internal/provider/codex/device_identity_test.go
+++ b/internal/provider/codex/device_identity_test.go
@@ -1,0 +1,82 @@
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestInstallationIDIsStableAndAccountScoped(t *testing.T) {
+	first, err := InstallationID("account-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, _ := InstallationID("account-1")
+	second, _ := InstallationID("account-2")
+	if first != repeated || first == second {
+		t.Fatalf("IDs = %q, %q, %q", first, repeated, second)
+	}
+	if want := "1b6b7b36-ce24-43fa-9a63-3d8d25f561f1"; first != want {
+		t.Fatalf("ID = %q, want stable vector %q", first, want)
+	}
+	if len(first) != 36 || first[14] != '4' || !strings.ContainsRune("89ab", rune(first[19])) {
+		t.Fatalf("ID is not a UUIDv4 value: %q", first)
+	}
+	if _, err = InstallationID(""); err == nil {
+		t.Fatal("empty account ID was accepted")
+	}
+}
+
+func TestApplyDeviceIdentityRewritesOnlyInstallationFields(t *testing.T) {
+	body := map[string]any{"client_metadata": map[string]any{
+		"session_id":              "session-1",
+		"x-codex-installation-id": "old-device",
+		"x-codex-turn-metadata":   `{"installation_id":"old-device","turn_id":"turn-1"}`,
+	}}
+	if err := ApplyDeviceIdentity(body, "stable-device"); err != nil {
+		t.Fatal(err)
+	}
+	metadata := body["client_metadata"].(map[string]any)
+	if metadata["x-codex-installation-id"] != "stable-device" || metadata["session_id"] != "session-1" {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	var turn map[string]any
+	if err := json.Unmarshal([]byte(metadata["x-codex-turn-metadata"].(string)), &turn); err != nil {
+		t.Fatal(err)
+	}
+	if turn["installation_id"] != "stable-device" || turn["turn_id"] != "turn-1" {
+		t.Fatalf("turn metadata = %#v", turn)
+	}
+}
+
+func TestDeviceIdentityHeadersCloneAndPreserveMalformedMetadata(t *testing.T) {
+	source := http.Header{
+		"X-Codex-Installation-Id": []string{"old-device"},
+		"X-Codex-Turn-Metadata":   []string{`{"installation_id":"old-device","thread_id":"thread-1"}`},
+	}
+	headers := DeviceIdentityHeaders(source, "stable-device")
+	if source.Get("X-Codex-Installation-Id") != "old-device" || headers.Get("X-Codex-Installation-Id") != "stable-device" {
+		t.Fatalf("source=%#v rewritten=%#v", source, headers)
+	}
+	var turn map[string]any
+	if err := json.Unmarshal([]byte(headers.Get("X-Codex-Turn-Metadata")), &turn); err != nil {
+		t.Fatal(err)
+	}
+	if turn["installation_id"] != "stable-device" || turn["thread_id"] != "thread-1" {
+		t.Fatalf("turn metadata = %#v", turn)
+	}
+
+	malformed := http.Header{"X-Codex-Turn-Metadata": []string{"not-json"}}
+	if got := DeviceIdentityHeaders(malformed, "stable-device").Get("X-Codex-Turn-Metadata"); got != "not-json" {
+		t.Fatalf("malformed metadata = %q", got)
+	}
+}
+
+func TestApplyDeviceIdentityRejectsNonObjectClientMetadata(t *testing.T) {
+	err := ApplyDeviceIdentity(map[string]any{"client_metadata": "invalid"}, "stable-device")
+	if !errors.Is(err, ErrInvalidClientMetadata) {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- derive a stable Codex installation ID from the selected provider account
- keep installation identity consistent across headers and client metadata
- preserve session, thread, turn, and cache identifiers while rebinding identity on failover
- document the intentionally narrow account-device identity design

## Testing

- `make test`
- `make build`