### PR TITLE
Use prebuilt image for Docker Compose

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,15 +6,9 @@ on:
       - main
     tags:
       - "v*"
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev web-install web-test web-build test build compose-up compose-down
+.PHONY: dev web-install web-test web-build test build compose-up compose-dev-up compose-down
 
 dev:
 	cd web && npm run dev
@@ -19,7 +19,10 @@ build: web-build
 	go build ./cmd/subpool
 
 compose-up:
-	docker compose up -d --build
+	docker compose up -d
+
+compose-dev-up:
+	docker compose -f compose.yaml -f compose.dev.yaml up -d --build
 
 compose-down:
 	docker compose down

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ openssl rand -base64 32
 openssl rand -base64 32
 openssl rand -hex 32
 
-docker compose up -d --build
+docker compose up -d
 ```
 
-Replace every `replace-with-*` value, then open [http://localhost:8080](http://localhost:8080) and sign in with the administrator credentials from `.env`.
+Replace every `replace-with-*` value. Docker Compose pulls the latest published Subpool image from ECR Public; no local image build is required. Open [http://localhost:8080](http://localhost:8080) and sign in with the administrator credentials from `.env`.
 
 ## Connect and use
 
@@ -105,10 +105,12 @@ See [.env.example](.env.example) for configuration options.
 ## Development
 
 ```bash
-docker compose up -d --build
+make compose-dev-up
 make web-install
 make dev
 ```
+
+`compose.dev.yaml` builds `subpool:local` from the current source tree instead of pulling the published image.
 
 Before opening a pull request:
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,6 @@
+services:
+  subpool:
+    image: subpool:local
+    pull_policy: build
+    build:
+      context: .

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,9 +2,8 @@ name: subpool
 
 services:
   subpool:
-    image: subpool:local
-    build:
-      context: .
+    image: ${SUBPOOL_IMAGE:-public.ecr.aws/cloudpilotai/subpool:latest}
+    pull_policy: always
     restart: unless-stopped
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

- pull the latest published Subpool image from ECR Public in the default Compose setup
- let end users update and start Subpool with `docker compose up -d` without a local build
- build every main-branch revision and keep local source builds in a dedicated development Compose override

## Testing

- `go test ./...`
- `cd web && npm test`
- `cd web && npm run build`
- validated default and development Compose configurations