### PR TITLE
Fix reset credits on HTTP deployments

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -9,6 +9,7 @@ import { PoolsPage } from './pages/PoolsPage'
 import { UsagePage } from './pages/UsagePage'
 import { SettingsPage } from './pages/SettingsPage'
 import { request } from './api'
+import { createIdempotencyKey } from './hooks/useResetCredits'
 
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -289,6 +290,14 @@ describe('Subpool console', () => {
     const body = JSON.parse(String(consume?.[1]?.body))
     expect(body.credit_id).toBe('credit-1')
     expect(body.idempotency_key).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it('creates reset idempotency keys without secure-context randomUUID', () => {
+    const key = createIdempotencyKey(undefined, (values) => {
+      values.forEach((_, index) => { values[index] = index })
+    })
+
+    expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
   })
 
   it('opens the supported model list for an account', async () => {

--- a/web/src/hooks/useResetCredits.ts
+++ b/web/src/hooks/useResetCredits.ts
@@ -9,6 +9,19 @@ export interface ResetCreditState {
   notice?: string
 }
 
+export function createIdempotencyKey(
+  randomUUID: (() => string) | undefined = typeof crypto.randomUUID === 'function' ? () => crypto.randomUUID() : undefined,
+  fillRandom: (values: Uint8Array<ArrayBuffer>) => void = (values) => { crypto.getRandomValues(values) },
+) {
+  if (randomUUID) return randomUUID()
+  const bytes = new Uint8Array(16)
+  fillRandom(bytes)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
 export function useResetCredits(reload: () => Promise<void>) {
   const [states, setStates] = useState<Record<string, ResetCreditState>>({})
   const [busyID, setBusyID] = useState('')
@@ -31,7 +44,7 @@ export function useResetCredits(reload: () => Promise<void>) {
     setBusyID(account.id)
     try {
       const result = await request<CodexResetConsumeResponse>(`/api/v1/provider-accounts/${account.id}/reset-credits/consume`, {
-        method: 'POST', body: JSON.stringify({ credit_id: creditID, idempotency_key: crypto.randomUUID() }),
+        method: 'POST', body: JSON.stringify({ credit_id: creditID, idempotency_key: createIdempotencyKey() }),
       })
       const notice = result.outcome === 'reset' || result.outcome === 'alreadyRedeemed'
         ? 'Full reset applied. Quota has been refreshed.'


### PR DESCRIPTION
## Summary

- Fall back to `crypto.getRandomValues()` when `crypto.randomUUID()` is unavailable on non-secure HTTP origins.
- Generate an RFC 4122 UUID v4 so reset-credit consumption reaches the backend with a valid idempotency key.
- Keep the native `randomUUID()` path for secure origins.

## Testing

- `make test build`