### PR TITLE
Refresh quota after reset credit use

### DIFF
--- a/internal/control/reset_credits.go
+++ b/internal/control/reset_credits.go
@@ -193,18 +193,57 @@ func (s *Server) consumeResetCredit(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadGateway, "failed to consume Codex reset credit")
 		return
 	}
-	if snapshot, marshalErr := json.Marshal(result.ResetCredits); marshalErr == nil {
-		_ = s.store.SetProviderResetCredits(ctx, account.ID, snapshot, time.Now().UTC())
-	}
 	auditResult := "failure"
 	if result.Outcome == "reset" || result.Outcome == "alreadyRedeemed" {
 		auditResult = "success"
-		if account.Status == domain.AccountCoolingDown || account.Status == domain.AccountExhausted {
-			_ = s.store.UpdateProviderStatus(r.Context(), account.ID, domain.AccountActive, nil)
+		quotaCtx, quotaCancel := context.WithTimeout(context.Background(), 7*time.Second)
+		s.persistResetQuota(quotaCtx, account, result.QuotaSnapshot)
+		quotaCancel()
+	}
+	if result.ResetCredits != nil {
+		cacheCtx, cacheCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if snapshot, marshalErr := json.Marshal(result.ResetCredits); marshalErr == nil {
+			_ = s.store.SetProviderResetCredits(cacheCtx, account.ID, snapshot, time.Now().UTC())
+		}
+		cacheCancel()
+	}
+	auditCtx, auditCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer auditCancel()
+	s.audit(auditCtx, "provider_account.reset_credit.consume", "provider_account", account.ID, auditResult)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) persistResetQuota(ctx context.Context, account domain.ProviderAccount, quota *codex.UsageSnapshot) {
+	if quota == nil && s.health != nil {
+		checked, err := s.health.CheckAccount(ctx, account.ID)
+		if err == nil && checked.LastHealthErrorCode == "" {
+			return
+		}
+		if err != nil {
+			slog.Warn("Codex reset quota reconciliation failed", "provider_account_id", account.ID, "error", err)
+		} else {
+			slog.Warn("Codex reset quota reconciliation was inconclusive", "provider_account_id", account.ID, "error_code", checked.LastHealthErrorCode)
 		}
 	}
-	s.audit(r.Context(), "provider_account.reset_credit.consume", "provider_account", account.ID, auditResult)
-	writeJSON(w, http.StatusOK, result)
+	if quota != nil {
+		snapshot, err := json.Marshal(quota)
+		if err != nil {
+			slog.Warn("Codex reset quota encoding failed", "provider_account_id", account.ID, "error", err)
+		} else if err = s.store.UpdateProviderDetails(ctx, account.ID, "", snapshot); err != nil {
+			slog.Warn("Codex reset quota update failed", "provider_account_id", account.ID, "error", err)
+		} else if quota.UsageAllowed != nil {
+			if err = s.store.SetProviderUsageAllowed(ctx, account.ID, *quota.UsageAllowed); err != nil {
+				slog.Warn("Codex reset availability update failed", "provider_account_id", account.ID, "error", err)
+			} else {
+				return
+			}
+		}
+	}
+	if account.Status == domain.AccountCoolingDown || account.Status == domain.AccountExhausted {
+		if err := s.store.UpdateProviderStatus(ctx, account.ID, domain.AccountActive, nil); err != nil {
+			slog.Warn("Codex reset status update failed", "provider_account_id", account.ID, "error", err)
+		}
+	}
 }
 
 func (s *Server) codexSubscriptionCredentials(ctx context.Context, accountID string) (domain.ProviderAccount, codex.Credentials, error) {

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -116,9 +116,27 @@ func (f *controlStore) UpdateProviderAccount(_ context.Context, id string, updat
 	}
 	return nil
 }
+func (f *controlStore) UpdateProviderDetails(_ context.Context, id, email string, quota []byte) error {
+	f.account.ID = id
+	if email != "" {
+		f.account.Email = email
+	}
+	f.account.QuotaSnapshot = append([]byte(nil), quota...)
+	return nil
+}
 func (f *controlStore) UpdateProviderStatus(_ context.Context, _ string, status string, cooldown *time.Time) error {
 	f.status = status
 	f.cooldown = cooldown
+	f.account.Status = status
+	return nil
+}
+func (f *controlStore) SetProviderUsageAllowed(_ context.Context, _ string, allowed bool) error {
+	if allowed && f.account.Status == domain.AccountExhausted {
+		f.account.Status = domain.AccountActive
+	} else if !allowed && (f.account.Status == domain.AccountActive || f.account.Status == domain.AccountCoolingDown || f.account.Status == domain.AccountExhausted) {
+		f.account.Status = domain.AccountExhausted
+	}
+	f.status = f.account.Status
 	return nil
 }
 func (f *controlStore) GetSettings(context.Context) (domain.Settings, error) {
@@ -195,6 +213,7 @@ type controlResetCredits struct {
 	creditID      string
 	idempotency   string
 	readCalls     int
+	afterConsume  func()
 }
 
 func (f *controlResetCredits) ReadResetCredits(_ context.Context, credentials codex.Credentials) (*codex.ResetCreditsSummary, error) {
@@ -207,6 +226,9 @@ func (f *controlResetCredits) ConsumeResetCredit(_ context.Context, credentials 
 	f.credentials = credentials
 	f.creditID = creditID
 	f.idempotency = idempotency
+	if f.afterConsume != nil {
+		f.afterConsume()
+	}
 	return f.consumeResult, f.err
 }
 
@@ -481,7 +503,11 @@ func TestCodexResetCreditsCanBeReadAndConsumed(t *testing.T) {
 	resets := server.resets.(*controlResetCredits)
 	expiresAt := int64(1800500000)
 	resets.credits = &codex.ResetCreditsSummary{AvailableCount: 2, Credits: []codex.ResetCredit{{ID: "credit-1", Status: "available", ExpiresAt: &expiresAt}}}
-	resets.consumeResult = codex.ConsumeResetCreditResult{Outcome: "reset", ResetCredits: &codex.ResetCreditsSummary{AvailableCount: 1}}
+	allowed := true
+	resets.consumeResult = codex.ConsumeResetCreditResult{
+		Outcome: "reset", ResetCredits: &codex.ResetCreditsSummary{AvailableCount: 1},
+		QuotaSnapshot: &codex.UsageSnapshot{UsageAllowed: &allowed, Weekly: &codex.UsageWindow{RemainingPercent: 100}},
+	}
 	mux := http.NewServeMux()
 	server.Register(mux)
 	cookie := loginCookie(t, mux)
@@ -508,7 +534,9 @@ func TestCodexResetCreditsCanBeReadAndConsumed(t *testing.T) {
 		t.Fatalf("refresh status=%d read calls=%d body=%s", refreshResponse.Code, resets.readCalls, refreshResponse.Body.String())
 	}
 
-	consumeRequest := httptest.NewRequest(http.MethodPost, "/api/v1/provider-accounts/account-1/reset-credits/consume", strings.NewReader(`{"credit_id":"credit-1","idempotency_key":"00000000-0000-4000-8000-000000000001"}`))
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	resets.afterConsume = cancelRequest
+	consumeRequest := httptest.NewRequest(http.MethodPost, "/api/v1/provider-accounts/account-1/reset-credits/consume", strings.NewReader(`{"credit_id":"credit-1","idempotency_key":"00000000-0000-4000-8000-000000000001"}`)).WithContext(requestCtx)
 	consumeRequest.AddCookie(cookie)
 	consumeResponse := httptest.NewRecorder()
 	mux.ServeHTTP(consumeResponse, consumeRequest)
@@ -520,6 +548,10 @@ func TestCodexResetCreditsCanBeReadAndConsumed(t *testing.T) {
 	}
 	if st.status != domain.AccountActive || st.cooldown != nil {
 		t.Fatalf("status=%s cooldown=%v", st.status, st.cooldown)
+	}
+	var quota codex.UsageSnapshot
+	if err = json.Unmarshal(st.account.QuotaSnapshot, &quota); err != nil || quota.Weekly == nil || quota.Weekly.RemainingPercent != 100 || quota.UsageAllowed == nil || !*quota.UsageAllowed {
+		t.Fatalf("quota = %#v, error = %v", quota, err)
 	}
 	if len(st.audits) != 1 || st.audits[0].Action != "provider_account.reset_credit.consume" || st.audits[0].Result != "success" {
 		t.Fatalf("audits = %#v", st.audits)

--- a/internal/provider/codex/appserver.go
+++ b/internal/provider/codex/appserver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -32,8 +33,9 @@ type ResetCreditsSummary struct {
 }
 
 type ConsumeResetCreditResult struct {
-	Outcome      string               `json:"outcome"`
-	ResetCredits *ResetCreditsSummary `json:"reset_credits"`
+	Outcome       string               `json:"outcome"`
+	ResetCredits  *ResetCreditsSummary `json:"reset_credits"`
+	QuotaSnapshot *UsageSnapshot       `json:"quota_snapshot,omitempty"`
 }
 
 type Model struct {
@@ -66,7 +68,8 @@ func (a *AppServer) ReadResetCredits(ctx context.Context, credentials Credential
 		return nil, err
 	}
 	defer session.close()
-	return session.readResetCredits(3)
+	snapshot, err := session.readRateLimits(3)
+	return snapshot.ResetCredits, err
 }
 
 func (a *AppServer) ConsumeResetCredit(ctx context.Context, credentials Credentials, creditID, idempotencyKey string) (ConsumeResetCreditResult, error) {
@@ -85,11 +88,12 @@ func (a *AppServer) ConsumeResetCredit(ctx context.Context, credentials Credenti
 	if err = session.call(3, "account/rateLimitResetCredit/consume", params, &consumed); err != nil {
 		return ConsumeResetCreditResult{}, err
 	}
-	credits, err := session.readResetCredits(4)
+	snapshot, err := session.readRateLimits(4)
 	if err != nil {
-		return ConsumeResetCreditResult{}, err
+		slog.Warn("Codex reset completed but rate limit refresh failed", "outcome", consumed.Outcome, "error", err)
+		return ConsumeResetCreditResult{Outcome: consumed.Outcome}, nil
 	}
-	return ConsumeResetCreditResult{Outcome: consumed.Outcome, ResetCredits: credits}, nil
+	return ConsumeResetCreditResult{Outcome: consumed.Outcome, ResetCredits: snapshot.ResetCredits, QuotaSnapshot: snapshot.Usage}, nil
 }
 
 func (a *AppServer) ListModels(ctx context.Context, credentials Credentials) ([]Model, error) {
@@ -219,8 +223,28 @@ func initializeAppServer(ctx context.Context, session *appServerSession) error {
 	return nil
 }
 
-func (s *appServerSession) readResetCredits(id int) (*ResetCreditsSummary, error) {
+type appServerRateLimitWindow struct {
+	UsedPercent        float64 `json:"usedPercent"`
+	WindowDurationMins *int64  `json:"windowDurationMins"`
+	ResetsAt           *int64  `json:"resetsAt"`
+}
+
+type appServerRateLimits struct {
+	PlanType             *string                   `json:"planType"`
+	Primary              *appServerRateLimitWindow `json:"primary"`
+	Secondary            *appServerRateLimitWindow `json:"secondary"`
+	RateLimitReachedType *string                   `json:"rateLimitReachedType"`
+	SpendControlReached  *bool                     `json:"spendControlReached"`
+}
+
+type appServerRateLimitSnapshot struct {
+	ResetCredits *ResetCreditsSummary
+	Usage        *UsageSnapshot
+}
+
+func (s *appServerSession) readRateLimits(id int) (appServerRateLimitSnapshot, error) {
 	var response struct {
+		RateLimits            appServerRateLimits `json:"rateLimits"`
 		RateLimitResetCredits *struct {
 			AvailableCount int `json:"availableCount"`
 			Credits        []struct {
@@ -235,22 +259,65 @@ func (s *appServerSession) readResetCredits(id int) (*ResetCreditsSummary, error
 		} `json:"rateLimitResetCredits"`
 	}
 	if err := s.call(id, "account/rateLimits/read", nil, &response); err != nil {
-		return nil, err
+		return appServerRateLimitSnapshot{}, err
 	}
+	result := appServerRateLimitSnapshot{Usage: normalizeAppServerRateLimits(response.RateLimits)}
 	if response.RateLimitResetCredits == nil {
-		return nil, nil
+		return result, nil
 	}
-	result := &ResetCreditsSummary{AvailableCount: response.RateLimitResetCredits.AvailableCount}
+	result.ResetCredits = &ResetCreditsSummary{AvailableCount: response.RateLimitResetCredits.AvailableCount}
 	if response.RateLimitResetCredits.Credits != nil {
-		result.Credits = make([]ResetCredit, 0, len(response.RateLimitResetCredits.Credits))
+		result.ResetCredits.Credits = make([]ResetCredit, 0, len(response.RateLimitResetCredits.Credits))
 		for _, credit := range response.RateLimitResetCredits.Credits {
-			result.Credits = append(result.Credits, ResetCredit{
+			result.ResetCredits.Credits = append(result.ResetCredits.Credits, ResetCredit{
 				ID: credit.ID, ResetType: credit.ResetType, Status: credit.Status, GrantedAt: credit.GrantedAt,
 				ExpiresAt: credit.ExpiresAt, Title: credit.Title, Description: credit.Description,
 			})
 		}
 	}
 	return result, nil
+}
+
+func normalizeAppServerRateLimits(limits appServerRateLimits) *UsageSnapshot {
+	if limits.PlanType == nil && limits.Primary == nil && limits.Secondary == nil && limits.RateLimitReachedType == nil && limits.SpendControlReached == nil {
+		return nil
+	}
+	allowed := true
+	snapshot := &UsageSnapshot{UsageAllowed: &allowed}
+	if limits.PlanType != nil {
+		snapshot.PlanType = *limits.PlanType
+	}
+	primary := normalizeAppServerWindow(limits.Primary)
+	secondary := normalizeAppServerWindow(limits.Secondary)
+	snapshot.FiveHour = primary
+	snapshot.Weekly = secondary
+	const weeklyWindowSeconds = 6 * 24 * 60 * 60
+	if primary != nil && primary.WindowSeconds >= weeklyWindowSeconds {
+		snapshot.Weekly = primary
+		snapshot.FiveHour = secondary
+	} else if secondary != nil && secondary.WindowSeconds < weeklyWindowSeconds {
+		snapshot.Weekly = nil
+	}
+	if limits.RateLimitReachedType != nil && *limits.RateLimitReachedType != "" && *limits.RateLimitReachedType != "unknown" {
+		snapshot.markUsageBlocked(*limits.RateLimitReachedType)
+	} else if limits.SpendControlReached != nil && *limits.SpendControlReached {
+		snapshot.markUsageBlocked("spend_control_reached")
+	}
+	return snapshot
+}
+
+func normalizeAppServerWindow(window *appServerRateLimitWindow) *UsageWindow {
+	if window == nil {
+		return nil
+	}
+	var durationSeconds, resetAt int64
+	if window.WindowDurationMins != nil {
+		durationSeconds = *window.WindowDurationMins * 60
+	}
+	if window.ResetsAt != nil {
+		resetAt = *window.ResetsAt
+	}
+	return normalizeUsageWindow(&usageWindowResponse{UsedPercent: window.UsedPercent, WindowSeconds: durationSeconds, ResetAt: resetAt})
 }
 
 func (s *appServerSession) call(id int, method string, params any, target any) error {

--- a/internal/provider/codex/appserver_test.go
+++ b/internal/provider/codex/appserver_test.go
@@ -30,7 +30,7 @@ func TestAppServerReadsAndConsumesResetCredits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Outcome != "reset" || result.ResetCredits == nil || result.ResetCredits.AvailableCount != 1 {
+	if result.Outcome != "reset" || result.ResetCredits == nil || result.ResetCredits.AvailableCount != 1 || result.QuotaSnapshot == nil || result.QuotaSnapshot.Weekly == nil || result.QuotaSnapshot.Weekly.RemainingPercent != 100 || result.QuotaSnapshot.UsageAllowed == nil || !*result.QuotaSnapshot.UsageAllowed {
 		t.Fatalf("result = %#v", result)
 	}
 	models, err := client.ListModels(ctx, credentials)
@@ -39,6 +39,21 @@ func TestAppServerReadsAndConsumesResetCredits(t *testing.T) {
 	}
 	if len(models) != 1 || models[0].Model != "model-alpha" || models[0].DisplayName != "Model Alpha" || len(models[0].SupportedReasoningEfforts) != 1 {
 		t.Fatalf("models = %#v", models)
+	}
+}
+
+func TestAppServerPreservesSuccessfulResetWhenSnapshotRefreshFails(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "codex-test")
+	wrapper := fmt.Sprintf("#!/bin/sh\nSUBPOOL_CODEX_HELPER=1 SUBPOOL_CODEX_FAIL_POST_RESET_READ=1 exec %q -test.run=TestCodexAppServerHelperProcess -- \"$@\"\n", os.Args[0])
+	if err := os.WriteFile(executable, []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	client := &AppServer{executable: executable}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result, err := client.ConsumeResetCredit(ctx, Credentials{AccessToken: "test-access-token", AccountID: "test-account"}, "credit-1", "00000000-0000-4000-8000-000000000001")
+	if err != nil || result.Outcome != "reset" || result.ResetCredits != nil || result.QuotaSnapshot != nil {
+		t.Fatalf("result = %#v, error = %v", result, err)
 	}
 }
 
@@ -134,12 +149,23 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 			consumed = true
 			result = map[string]any{"outcome": "reset"}
 		case "account/rateLimits/read":
+			if consumed && os.Getenv("SUBPOOL_CODEX_FAIL_POST_RESET_READ") == "1" {
+				response, _ := json.Marshal(map[string]any{"id": request.ID, "error": map[string]any{"code": -32000, "message": "rate limit refresh failed"}})
+				_, _ = fmt.Fprintln(os.Stdout, string(response))
+				continue
+			}
 			available := 2
+			usedPercent := 25
 			if consumed {
 				available = 1
+				usedPercent = 0
 			}
 			result = map[string]any{
-				"rateLimits": map[string]any{"limitId": "codex", "primary": map[string]any{"usedPercent": 25}},
+				"rateLimits": map[string]any{
+					"limitId": "codex", "planType": "plus",
+					"primary":   map[string]any{"usedPercent": usedPercent, "windowDurationMins": 300, "resetsAt": 1800000000},
+					"secondary": map[string]any{"usedPercent": usedPercent, "windowDurationMins": 10080, "resetsAt": 1800500000},
+				},
 				"rateLimitResetCredits": map[string]any{
 					"availableCount": available,
 					"credits": []map[string]any{{

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -267,7 +267,8 @@ describe('Subpool console', () => {
     vi.mocked(fetch).mockImplementation(async (input, init) => {
       const path = String(input)
       if (path === '/api/v1/provider-accounts') return json({ data: [{
-        id: 'account-1', display_name: 'Primary Codex', provider: 'codex', credential_type: 'subscription_oauth', status: 'exhausted', assigned_api_keys: 1,
+        id: 'account-1', display_name: 'Primary Codex', provider: 'codex', credential_type: 'subscription_oauth', status: availableCount === 2 ? 'exhausted' : 'active', assigned_api_keys: 1,
+        quota_snapshot: { usage_allowed: availableCount !== 2, weekly: { used_percent: availableCount === 2 ? 100 : 0, remaining_percent: availableCount === 2 ? 0 : 100, window_seconds: 604800, reset_at: 1800500000 } },
       }] })
       if ((path === '/api/v1/provider-accounts/account-1/reset-credits' || path === '/api/v1/provider-accounts/account-1/reset-credits?refresh=true') && !init?.method) return json({
         reset_credits: { available_count: availableCount, credits: [{ id: 'credit-1', reset_type: 'codexRateLimits', status: 'available', granted_at: 1800000000, expires_at: 1800500000 }] },
@@ -286,6 +287,8 @@ describe('Subpool console', () => {
     await user.click((await screen.findAllByRole('button', { name: 'Use full reset' })).at(-1)!)
 
     expect(await screen.findByText(/Full reset applied/)).toBeInTheDocument()
+    expect(await screen.findByText('100%')).toBeInTheDocument()
+    expect(screen.getByText('Routing enabled')).toBeInTheDocument()
     const consume = vi.mocked(fetch).mock.calls.find(([path, options]) => String(path).endsWith('/reset-credits/consume') && options?.method === 'POST')
     const body = JSON.parse(String(consume?.[1]?.body))
     expect(body.credit_id).toBe('credit-1')

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,6 +69,7 @@ export interface CodexResetCreditsResponse {
 export interface CodexResetConsumeResponse {
 	outcome: 'reset' | 'alreadyRedeemed' | 'nothingToReset' | 'noCredit'
 	reset_credits: CodexResetCredits | null
+	quota_snapshot?: ProviderAccount['quota_snapshot']
 }
 
 export interface GlobalSettings {


### PR DESCRIPTION
## Summary
- retain the post-reset Codex rate-limit snapshot returned by app-server
- persist refreshed quota and routing availability immediately after a successful reset
- cover the exhausted-to-100% UI transition with regression tests

## Testing
- make test build