### PR TITLE
Fix quota freshness after probe failures

### DIFF
--- a/internal/control/reset_credits.go
+++ b/internal/control/reset_credits.go
@@ -216,20 +216,20 @@ func (s *Server) consumeResetCredit(w http.ResponseWriter, r *http.Request) {
 func (s *Server) persistResetQuota(ctx context.Context, account domain.ProviderAccount, quota *codex.UsageSnapshot) {
 	if quota == nil && s.health != nil {
 		checked, err := s.health.CheckAccount(ctx, account.ID)
-		if err == nil && checked.LastHealthErrorCode == "" {
+		if err == nil && checked.LastQuotaErrorCode == "" {
 			return
 		}
 		if err != nil {
 			slog.Warn("Codex reset quota reconciliation failed", "provider_account_id", account.ID, "error", err)
 		} else {
-			slog.Warn("Codex reset quota reconciliation was inconclusive", "provider_account_id", account.ID, "error_code", checked.LastHealthErrorCode)
+			slog.Warn("Codex reset quota reconciliation was inconclusive", "provider_account_id", account.ID, "error_code", checked.LastQuotaErrorCode)
 		}
 	}
 	if quota != nil {
 		snapshot, err := json.Marshal(quota)
 		if err != nil {
 			slog.Warn("Codex reset quota encoding failed", "provider_account_id", account.ID, "error", err)
-		} else if err = s.store.UpdateProviderDetails(ctx, account.ID, "", snapshot); err != nil {
+		} else if err = s.store.UpdateProviderDetails(ctx, account.ID, "", snapshot, time.Now().UTC()); err != nil {
 			slog.Warn("Codex reset quota update failed", "provider_account_id", account.ID, "error", err)
 		} else if quota.UsageAllowed != nil {
 			if err = s.store.SetProviderUsageAllowed(ctx, account.ID, *quota.UsageAllowed); err != nil {

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -116,12 +116,14 @@ func (f *controlStore) UpdateProviderAccount(_ context.Context, id string, updat
 	}
 	return nil
 }
-func (f *controlStore) UpdateProviderDetails(_ context.Context, id, email string, quota []byte) error {
+func (f *controlStore) UpdateProviderDetails(_ context.Context, id, email string, quota []byte, checkedAt time.Time) error {
 	f.account.ID = id
 	if email != "" {
 		f.account.Email = email
 	}
 	f.account.QuotaSnapshot = append([]byte(nil), quota...)
+	f.account.QuotaCheckedAt = &checkedAt
+	f.account.LastQuotaErrorCode = ""
 	return nil
 }
 func (f *controlStore) UpdateProviderStatus(_ context.Context, _ string, status string, cooldown *time.Time) error {
@@ -498,7 +500,7 @@ func TestCodexResetCreditsCanBeReadAndConsumed(t *testing.T) {
 	}
 	st.account = domain.ProviderAccount{
 		ID: "account-1", Provider: domain.ProviderCodex, CredentialType: domain.CredentialSubscription,
-		CredentialCiphertext: encrypted, CredentialVersion: 1, Status: domain.AccountExhausted,
+		CredentialCiphertext: encrypted, CredentialVersion: 1, Status: domain.AccountExhausted, LastQuotaErrorCode: "quota_probe_rate_limited",
 	}
 	resets := server.resets.(*controlResetCredits)
 	expiresAt := int64(1800500000)
@@ -552,6 +554,9 @@ func TestCodexResetCreditsCanBeReadAndConsumed(t *testing.T) {
 	var quota codex.UsageSnapshot
 	if err = json.Unmarshal(st.account.QuotaSnapshot, &quota); err != nil || quota.Weekly == nil || quota.Weekly.RemainingPercent != 100 || quota.UsageAllowed == nil || !*quota.UsageAllowed {
 		t.Fatalf("quota = %#v, error = %v", quota, err)
+	}
+	if st.account.QuotaCheckedAt == nil || st.account.LastQuotaErrorCode != "" {
+		t.Fatalf("quota freshness = %#v", st.account)
 	}
 	if len(st.audits) != 1 || st.audits[0].Action != "provider_account.reset_credit.consume" || st.audits[0].Result != "success" {
 		t.Fatalf("audits = %#v", st.audits)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -39,6 +39,8 @@ type ProviderAccount struct {
 	NextHealthCheckAt    *time.Time      `json:"next_health_check_at,omitempty"`
 	AssignedAPIKeys      int             `json:"assigned_api_keys"`
 	QuotaSnapshot        json.RawMessage `json:"quota_snapshot"`
+	QuotaCheckedAt       *time.Time      `json:"quota_checked_at,omitempty"`
+	LastQuotaErrorCode   string          `json:"last_quota_error_code,omitempty"`
 	CooldownUntil        *time.Time      `json:"cooldown_until,omitempty"`
 	LastSuccessAt        *time.Time      `json:"last_success_at,omitempty"`
 	LastFailureAt        *time.Time      `json:"last_failure_at,omitempty"`

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -36,13 +36,14 @@ type CompatibleModels interface {
 }
 
 type Result struct {
-	HealthStatus  string
-	ErrorCode     string
-	Email         string
-	QuotaSnapshot json.RawMessage
-	UsageAllowed  *bool
-	AuthFailed    bool
-	Failure       bool
+	HealthStatus   string
+	ErrorCode      string
+	QuotaErrorCode string
+	Email          string
+	QuotaSnapshot  json.RawMessage
+	UsageAllowed   *bool
+	AuthFailed     bool
+	Failure        bool
 }
 
 type Checker struct {
@@ -60,24 +61,30 @@ func NewChecker(st store.Store, cipher Cipher, codexUsage CodexUsage, compatible
 func (c *Checker) Check(ctx context.Context, account domain.ProviderAccount) Result {
 	plaintext, err := c.cipher.Decrypt(account.CredentialCiphertext)
 	if err != nil {
-		return Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "credential_unavailable", Failure: true}
+		result := Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "credential_unavailable", Failure: true}
+		if account.Provider == domain.ProviderCodex {
+			result.QuotaErrorCode = result.ErrorCode
+		}
+		return result
 	}
 	switch account.Provider {
 	case domain.ProviderCodex:
 		var credentials codex.Credentials
 		if json.Unmarshal(plaintext, &credentials) != nil {
-			return Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "credential_unavailable", Failure: true}
+			return Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "credential_unavailable", QuotaErrorCode: "credential_unavailable", Failure: true}
 		}
 		snapshot, usageErr := c.codex.Usage(ctx, credentials)
 		err = usageErr
 		if err == nil {
 			raw, marshalErr := json.Marshal(snapshot)
 			if marshalErr != nil {
-				return Result{HealthStatus: domain.HealthUnknown, ErrorCode: "invalid_usage_response", Failure: true}
+				return Result{HealthStatus: domain.HealthUnknown, ErrorCode: "invalid_usage_response", QuotaErrorCode: "invalid_usage_response", Failure: true}
 			}
 			return Result{HealthStatus: domain.HealthHealthy, Email: credentials.Email, QuotaSnapshot: raw, UsageAllowed: snapshot.UsageAllowed}
 		}
-		return classifyError(err)
+		result := classifyError(err)
+		result.QuotaErrorCode = result.ErrorCode
+		return result
 	case domain.ProviderOpenAICompatible:
 		var credentials openaicompat.Credentials
 		if json.Unmarshal(plaintext, &credentials) != nil {
@@ -114,6 +121,12 @@ func (c *Checker) ApplyNewAccount(account *domain.ProviderAccount, result Result
 	account.HealthStatus = result.HealthStatus
 	account.Email = result.Email
 	account.QuotaSnapshot = result.QuotaSnapshot
+	if len(result.QuotaSnapshot) > 0 {
+		account.QuotaCheckedAt = &now
+		account.LastQuotaErrorCode = ""
+	} else if result.QuotaErrorCode != "" {
+		account.LastQuotaErrorCode = result.QuotaErrorCode
+	}
 	account.LastHealthErrorCode = result.ErrorCode
 	account.LastCheckedAt = &now
 	account.NextHealthCheckAt = &next
@@ -209,7 +222,10 @@ func (c *Checker) persist(ctx context.Context, accountID string, result Result) 
 		return err
 	}
 	if result.Email != "" || len(result.QuotaSnapshot) > 0 {
-		return c.store.UpdateProviderDetails(ctx, accountID, result.Email, result.QuotaSnapshot)
+		return c.store.UpdateProviderDetails(ctx, accountID, result.Email, result.QuotaSnapshot, now)
+	}
+	if result.QuotaErrorCode != "" {
+		return c.store.SetProviderQuotaError(ctx, accountID, result.QuotaErrorCode)
 	}
 	return nil
 }
@@ -226,7 +242,7 @@ func classifyError(err error) Result {
 		case statusErr.StatusCode == http.StatusUnauthorized || statusErr.StatusCode == http.StatusForbidden:
 			return Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "authentication_failed", AuthFailed: true}
 		case statusErr.StatusCode == http.StatusTooManyRequests:
-			return Result{HealthStatus: domain.HealthHealthy}
+			return Result{HealthStatus: domain.HealthUnknown, ErrorCode: "quota_probe_rate_limited"}
 		case statusErr.StatusCode == http.StatusNotFound || statusErr.StatusCode == http.StatusMethodNotAllowed:
 			return Result{HealthStatus: domain.HealthUnknown, ErrorCode: "provider_unavailable", Failure: true}
 		case statusErr.StatusCode >= 500:

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -25,10 +25,13 @@ func (c testCompatible) Models(context.Context, openaicompat.Credentials) (*http
 	return &http.Response{StatusCode: c.status, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
 }
 
-type testCodexUsage struct{ snapshot codex.UsageSnapshot }
+type testCodexUsage struct {
+	snapshot codex.UsageSnapshot
+	err      error
+}
 
 func (c testCodexUsage) Usage(context.Context, codex.Credentials) (codex.UsageSnapshot, error) {
-	return c.snapshot, nil
+	return c.snapshot, c.err
 }
 
 func TestCodexHealthCheckReportsExhaustedUsage(t *testing.T) {
@@ -43,6 +46,23 @@ func TestCodexHealthCheckReportsExhaustedUsage(t *testing.T) {
 	checker.ApplyNewAccount(&account, result)
 	if account.Status != domain.AccountExhausted {
 		t.Fatalf("status = %q, want exhausted", account.Status)
+	}
+	if account.QuotaCheckedAt == nil || account.LastQuotaErrorCode != "" {
+		t.Fatalf("quota freshness = %#v", account)
+	}
+}
+
+func TestCodexHealthCheckTracksQuotaProbeFailure(t *testing.T) {
+	credentials, _ := json.Marshal(codex.Credentials{AccessToken: "access", AccountID: "account"})
+	account := domain.ProviderAccount{Provider: domain.ProviderCodex, CredentialCiphertext: []byte("encrypted")}
+	checker := NewChecker(nil, testCipher{plaintext: credentials}, testCodexUsage{err: &codex.HTTPStatusError{StatusCode: http.StatusTooManyRequests}}, nil)
+	result := checker.Check(context.Background(), account)
+	if result.HealthStatus != domain.HealthUnknown || result.ErrorCode != "quota_probe_rate_limited" || result.QuotaErrorCode != "quota_probe_rate_limited" {
+		t.Fatalf("result = %#v", result)
+	}
+	checker.ApplyNewAccount(&account, result)
+	if account.LastQuotaErrorCode != "quota_probe_rate_limited" || account.QuotaCheckedAt != nil {
+		t.Fatalf("quota freshness = %#v", account)
 	}
 }
 
@@ -71,7 +91,7 @@ func TestClassifyCodexStatusError(t *testing.T) {
 	}{
 		{name: "unauthorized", statusCode: http.StatusUnauthorized, want: Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "authentication_failed", AuthFailed: true}},
 		{name: "forbidden", statusCode: http.StatusForbidden, want: Result{HealthStatus: domain.HealthUnhealthy, ErrorCode: "authentication_failed", AuthFailed: true}},
-		{name: "rate limited", statusCode: http.StatusTooManyRequests, want: Result{HealthStatus: domain.HealthHealthy}},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, want: Result{HealthStatus: domain.HealthUnknown, ErrorCode: "quota_probe_rate_limited"}},
 		{name: "not found", statusCode: http.StatusNotFound, want: Result{HealthStatus: domain.HealthUnknown, ErrorCode: "provider_unavailable", Failure: true}},
 		{name: "method not allowed", statusCode: http.StatusMethodNotAllowed, want: Result{HealthStatus: domain.HealthUnknown, ErrorCode: "provider_unavailable", Failure: true}},
 		{name: "provider failure", statusCode: http.StatusBadGateway, want: Result{HealthStatus: domain.HealthUnknown, ErrorCode: "provider_5xx", Failure: true}},

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -87,10 +87,10 @@ func (p *Postgres) migrate(ctx context.Context) error {
 func (p *Postgres) CreateProviderAccount(ctx context.Context, a domain.ProviderAccount) error {
 	_, err := p.pool.Exec(ctx, `INSERT INTO provider_accounts
 		(id, provider, credential_type, display_name, email, subject_hmac, credential_ciphertext, credential_version, status, quota_snapshot,
-		 health_status,last_checked_at,last_health_error_code,consecutive_health_failures,next_health_check_at)
-		VALUES ($1,$2,$3,$4,NULLIF($5,''),$6,$7,$8,$9,COALESCE($10,'{}'::jsonb),COALESCE(NULLIF($11,''),'unknown'),$12,NULLIF($13,''),$14,$15)`,
+		 quota_checked_at,last_quota_error_code,health_status,last_checked_at,last_health_error_code,consecutive_health_failures,next_health_check_at)
+		VALUES ($1,$2,$3,$4,NULLIF($5,''),$6,$7,$8,$9,COALESCE($10,'{}'::jsonb),$11,NULLIF($12,''),COALESCE(NULLIF($13,''),'unknown'),$14,NULLIF($15,''),$16,$17)`,
 		a.ID, a.Provider, a.CredentialType, a.DisplayName, a.Email, a.SubjectHMAC, a.CredentialCiphertext, a.CredentialVersion, a.Status, nullableJSON(a.QuotaSnapshot),
-		a.HealthStatus, a.LastCheckedAt, a.LastHealthErrorCode, a.ConsecutiveFailures, a.NextHealthCheckAt)
+		a.QuotaCheckedAt, a.LastQuotaErrorCode, a.HealthStatus, a.LastCheckedAt, a.LastHealthErrorCode, a.ConsecutiveFailures, a.NextHealthCheckAt)
 	return wrapDB("create provider account", err)
 }
 
@@ -98,7 +98,7 @@ func (p *Postgres) ListProviderAccounts(ctx context.Context) ([]domain.ProviderA
 	rows, err := p.pool.Query(ctx, `SELECT a.id,a.provider,a.credential_type,a.display_name,COALESCE(a.email,''),a.credential_version,a.status,
 		a.fast_mode_enabled,
 		(SELECT count(*) FROM api_key_account_bindings b JOIN api_keys k ON k.id=b.api_key_id WHERE b.provider_account_id=a.id AND k.revoked_at IS NULL AND (k.expires_at IS NULL OR k.expires_at>now())),
-		a.quota_snapshot,a.cooldown_until,a.last_success_at,a.last_failure_at,a.health_status,a.last_checked_at,COALESCE(a.last_health_error_code,''),a.consecutive_health_failures,a.next_health_check_at,a.created_at,a.updated_at
+		a.quota_snapshot,a.quota_checked_at,COALESCE(a.last_quota_error_code,''),a.cooldown_until,a.last_success_at,a.last_failure_at,a.health_status,a.last_checked_at,COALESCE(a.last_health_error_code,''),a.consecutive_health_failures,a.next_health_check_at,a.created_at,a.updated_at
 		FROM provider_accounts a ORDER BY a.created_at`)
 	if err != nil {
 		return nil, wrapDB("list provider accounts", err)
@@ -108,7 +108,7 @@ func (p *Postgres) ListProviderAccounts(ctx context.Context) ([]domain.ProviderA
 	for rows.Next() {
 		var a domain.ProviderAccount
 		if err = rows.Scan(&a.ID, &a.Provider, &a.CredentialType, &a.DisplayName, &a.Email, &a.CredentialVersion, &a.Status,
-			&a.FastModeEnabled, &a.AssignedAPIKeys, &a.QuotaSnapshot, &a.CooldownUntil, &a.LastSuccessAt, &a.LastFailureAt, &a.HealthStatus, &a.LastCheckedAt, &a.LastHealthErrorCode, &a.ConsecutiveFailures, &a.NextHealthCheckAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
+			&a.FastModeEnabled, &a.AssignedAPIKeys, &a.QuotaSnapshot, &a.QuotaCheckedAt, &a.LastQuotaErrorCode, &a.CooldownUntil, &a.LastSuccessAt, &a.LastFailureAt, &a.HealthStatus, &a.LastCheckedAt, &a.LastHealthErrorCode, &a.ConsecutiveFailures, &a.NextHealthCheckAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
 			return nil, wrapDB("scan provider account", err)
 		}
 		out = append(out, a)
@@ -143,15 +143,25 @@ func (p *Postgres) ListPoolProviderAccounts(ctx context.Context, poolID string) 
 func (p *Postgres) GetProviderAccount(ctx context.Context, id string) (domain.ProviderAccount, error) {
 	var a domain.ProviderAccount
 	err := p.pool.QueryRow(ctx, `SELECT id,provider,credential_type,display_name,COALESCE(email,''),credential_ciphertext,credential_version,status,
-		fast_mode_enabled,quota_snapshot,cooldown_until,last_success_at,last_failure_at,health_status,last_checked_at,COALESCE(last_health_error_code,''),consecutive_health_failures,next_health_check_at,created_at,updated_at FROM provider_accounts WHERE id=$1`, id).
+		fast_mode_enabled,quota_snapshot,quota_checked_at,COALESCE(last_quota_error_code,''),cooldown_until,last_success_at,last_failure_at,health_status,last_checked_at,COALESCE(last_health_error_code,''),consecutive_health_failures,next_health_check_at,created_at,updated_at FROM provider_accounts WHERE id=$1`, id).
 		Scan(&a.ID, &a.Provider, &a.CredentialType, &a.DisplayName, &a.Email, &a.CredentialCiphertext, &a.CredentialVersion, &a.Status,
-			&a.FastModeEnabled, &a.QuotaSnapshot, &a.CooldownUntil, &a.LastSuccessAt, &a.LastFailureAt, &a.HealthStatus, &a.LastCheckedAt, &a.LastHealthErrorCode, &a.ConsecutiveFailures, &a.NextHealthCheckAt, &a.CreatedAt, &a.UpdatedAt)
+			&a.FastModeEnabled, &a.QuotaSnapshot, &a.QuotaCheckedAt, &a.LastQuotaErrorCode, &a.CooldownUntil, &a.LastSuccessAt, &a.LastFailureAt, &a.HealthStatus, &a.LastCheckedAt, &a.LastHealthErrorCode, &a.ConsecutiveFailures, &a.NextHealthCheckAt, &a.CreatedAt, &a.UpdatedAt)
 	return a, wrapDB("get provider account", err)
 }
 
-func (p *Postgres) UpdateProviderDetails(ctx context.Context, id, email string, quota []byte) error {
-	tag, err := p.pool.Exec(ctx, `UPDATE provider_accounts SET email=COALESCE(NULLIF($2,''),email),quota_snapshot=COALESCE($3,'{}'::jsonb),updated_at=now() WHERE id=$1`, id, email, nullableJSON(quota))
+func (p *Postgres) UpdateProviderDetails(ctx context.Context, id, email string, quota []byte, quotaCheckedAt time.Time) error {
+	tag, err := p.pool.Exec(ctx, `UPDATE provider_accounts SET
+		email=COALESCE(NULLIF($2,''),email),
+		quota_snapshot=COALESCE($3::jsonb,quota_snapshot),
+		quota_checked_at=CASE WHEN $3::jsonb IS NULL THEN quota_checked_at ELSE $4 END,
+		last_quota_error_code=CASE WHEN $3::jsonb IS NULL THEN last_quota_error_code ELSE NULL END,
+		updated_at=now() WHERE id=$1`, id, email, nullableJSON(quota), quotaCheckedAt)
 	return wrapMutation("update provider details", tag.RowsAffected(), err)
+}
+
+func (p *Postgres) SetProviderQuotaError(ctx context.Context, id, errorCode string) error {
+	tag, err := p.pool.Exec(ctx, `UPDATE provider_accounts SET last_quota_error_code=NULLIF($2,''),updated_at=now() WHERE id=$1`, id, errorCode)
+	return wrapMutation("set provider quota error", tag.RowsAffected(), err)
 }
 
 func (p *Postgres) GetProviderResetCredits(ctx context.Context, id string) ([]byte, *time.Time, error) {

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -134,15 +135,64 @@ func TestPostgresRequestSuccessPreservesBlockedAccountStatus(t *testing.T) {
 	if err = database.CreateProviderAccount(ctx, account); err != nil {
 		t.Fatal(err)
 	}
-	if err = database.SetProviderUsageAllowed(ctx, account.ID, false); err != nil {
+	checkedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	nextCheckAt := checkedAt.Add(5 * time.Minute)
+	if err = database.SetProviderHealth(ctx, account.ID, domain.HealthHealthy, "", checkedAt, nextCheckAt); err != nil {
 		t.Fatal(err)
 	}
-	if err = database.RecordRequestSuccess(ctx, account.ID, "00000000-0000-4000-8000-000000000704", time.Now().UTC()); err != nil {
+	quotaSnapshot := []byte(`{"weekly":{"remaining_percent":75}}`)
+	if err = database.UpdateProviderDetails(ctx, account.ID, "", quotaSnapshot, checkedAt); err != nil {
+		t.Fatal(err)
+	}
+	probeFailedAt := checkedAt.Add(time.Minute)
+	nextCheckAt = probeFailedAt.Add(5 * time.Minute)
+	if err = database.SetProviderHealth(ctx, account.ID, domain.HealthUnknown, "quota_probe_rate_limited", probeFailedAt, nextCheckAt); err != nil {
+		t.Fatal(err)
+	}
+	if err = database.SetProviderQuotaError(ctx, account.ID, "quota_probe_rate_limited"); err != nil {
+		t.Fatal(err)
+	}
+	if err = database.RecordRequestSuccess(ctx, account.ID, "00000000-0000-4000-8000-000000000704", probeFailedAt.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	stored, err := database.GetProviderAccount(ctx, account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.HealthStatus != domain.HealthHealthy || stored.LastHealthErrorCode != "" || stored.LastQuotaErrorCode != "quota_probe_rate_limited" {
+		t.Fatalf("account freshness after request success = %#v", stored)
+	}
+	var storedQuota struct {
+		Weekly struct {
+			RemainingPercent float64 `json:"remaining_percent"`
+		} `json:"weekly"`
+	}
+	if decodeErr := json.Unmarshal(stored.QuotaSnapshot, &storedQuota); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if stored.QuotaCheckedAt == nil || !stored.QuotaCheckedAt.Equal(checkedAt) || storedQuota.Weekly.RemainingPercent != 75 {
+		t.Fatalf("cached quota changed after request success = %#v", stored)
+	}
+	refreshedAt := probeFailedAt.Add(2 * time.Minute)
+	if err = database.UpdateProviderDetails(ctx, account.ID, "", []byte(`{"weekly":{"remaining_percent":70}}`), refreshedAt); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = database.GetProviderAccount(ctx, account.ID)
+	if err != nil || stored.LastQuotaErrorCode != "" || stored.QuotaCheckedAt == nil || !stored.QuotaCheckedAt.Equal(refreshedAt) {
+		t.Fatalf("quota freshness after successful refresh = %#v, %v", stored, err)
+	}
+	if err = database.SetProviderUsageAllowed(ctx, account.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if err = database.RecordRequestSuccess(ctx, account.ID, "00000000-0000-4000-8000-000000000704", probeFailedAt.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = database.GetProviderAccount(ctx, account.ID)
 	if err != nil || stored.Status != domain.AccountExhausted {
 		t.Fatalf("account after request success = %#v, %v", stored, err)
+	}
+	if stored.NextHealthCheckAt == nil || !stored.NextHealthCheckAt.Equal(nextCheckAt) {
+		t.Fatalf("quota check was postponed after request success: %#v", stored)
 	}
 	if err = database.SetProviderUsageAllowed(ctx, account.ID, true); err != nil {
 		t.Fatal(err)

--- a/internal/store/routing.go
+++ b/internal/store/routing.go
@@ -285,7 +285,7 @@ func (p *Postgres) RecordRequestSuccess(ctx context.Context, accountID, keyID st
 			cooldown_until=CASE WHEN status IN ('disabled','exhausted') THEN cooldown_until ELSE NULL END,
 			last_success_at=$3,
 			health_status='healthy',last_checked_at=$3,last_health_error_code=NULL,consecutive_health_failures=0,
-		next_health_check_at=$3::timestamptz+interval '5 minutes',updated_at=now() WHERE id=$1 RETURNING id
+			updated_at=now() WHERE id=$1 RETURNING id
 	) UPDATE api_keys SET last_used_at=$3 WHERE id=$2 AND EXISTS(SELECT 1 FROM account)`, accountID, keyID, occurredAt)
 	return wrapDB("record request success", err)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,7 +24,8 @@ type Store interface {
 	ListPoolProviderAccounts(context.Context, string) ([]domain.ProviderAccount, error)
 	GetProviderAccount(context.Context, string) (domain.ProviderAccount, error)
 	UpdateProviderAccount(context.Context, string, domain.ProviderAccountUpdate) error
-	UpdateProviderDetails(context.Context, string, string, []byte) error
+	UpdateProviderDetails(context.Context, string, string, []byte, time.Time) error
+	SetProviderQuotaError(context.Context, string, string) error
 	DeleteProviderAccount(context.Context, string) error
 	UpdateProviderCredentialCAS(context.Context, string, int, []byte, int) (bool, error)
 	UpdateProviderStatus(context.Context, string, string, *time.Time) error

--- a/migrations/016_provider_quota_freshness.sql
+++ b/migrations/016_provider_quota_freshness.sql
@@ -1,0 +1,8 @@
+ALTER TABLE provider_accounts
+    ADD COLUMN IF NOT EXISTS quota_checked_at timestamptz,
+    ADD COLUMN IF NOT EXISTS last_quota_error_code text;
+
+UPDATE provider_accounts
+SET quota_checked_at = last_checked_at
+WHERE quota_checked_at IS NULL
+  AND quota_snapshot <> '{}'::jsonb;

--- a/web/src/components/accounts/AccountTable.test.tsx
+++ b/web/src/components/accounts/AccountTable.test.tsx
@@ -10,6 +10,7 @@ const baseAccount: ProviderAccount = {
   display_name: 'Team account',
   status: 'active',
   health_status: 'healthy',
+  quota_checked_at: '2026-09-10T08:00:00Z',
   quota_snapshot: {
     weekly: {
       used_percent: 25,
@@ -53,6 +54,7 @@ describe('AccountTable health states', () => {
       ...baseAccount,
       consecutive_health_failures: 1,
       last_health_error_code: 'provider_unavailable',
+      last_quota_error_code: 'provider_unavailable',
     })
 
     expect(screen.getByText('degraded')).toBeInTheDocument()
@@ -67,10 +69,37 @@ describe('AccountTable health states', () => {
       health_status: 'unhealthy',
       consecutive_health_failures: 3,
       last_health_error_code: 'provider_unavailable',
+      last_quota_error_code: 'provider_unavailable',
     })
 
     expect(screen.getByText('unhealthy')).toBeInTheDocument()
     expect(screen.getByText('Routing suspended')).toBeInTheDocument()
+    expect(screen.getByText('last known weekly capacity')).toBeInTheDocument()
+  })
+
+  it('labels cached capacity as last known when quota probing is rate limited', () => {
+    renderTable({
+      ...baseAccount,
+      health_status: 'unknown',
+      last_health_error_code: 'quota_probe_rate_limited',
+      last_quota_error_code: 'quota_probe_rate_limited',
+    })
+
+    expect(screen.getByText('unchecked')).toBeInTheDocument()
+    expect(screen.getByText('last known weekly capacity')).toBeInTheDocument()
+    expect(screen.getByText('quota probe rate limited')).toBeInTheDocument()
+  })
+
+  it('keeps cached capacity marked as last known after a successful model request', () => {
+    renderTable({
+      ...baseAccount,
+      health_status: 'healthy',
+      last_success_at: '2026-09-10T08:01:00Z',
+      last_quota_error_code: 'quota_probe_rate_limited',
+    })
+
+    expect(screen.getByText('healthy')).toBeInTheDocument()
+    expect(screen.getByText('Routing enabled')).toBeInTheDocument()
     expect(screen.getByText('last known weekly capacity')).toBeInTheDocument()
   })
 

--- a/web/src/components/accounts/AccountTable.tsx
+++ b/web/src/components/accounts/AccountTable.tsx
@@ -57,9 +57,10 @@ export function AccountTable({ accounts, busyID, resetBusyID, resetStates, onMod
       const unavailable = effectiveStatus !== 'active'
       const degraded = !unavailable && health !== 'unhealthy' && (account.consecutive_health_failures ?? 0) > 0
       const healthStatus = degraded ? 'unknown' : health
+      const quotaIsLastKnown = !account.quota_checked_at || Boolean(account.last_quota_error_code)
       const availabilityLabel = unavailable ? statusLabel(effectiveStatus) : degraded ? 'degraded' : healthLabel(health)
       const routingLabel = usageBlocked ? 'Routing suspended' : unavailable ? `${healthLabel(health)} health` : health === 'unhealthy' ? 'Routing suspended' : degraded ? 'Routing enabled while retrying' : 'Routing enabled'
-      const capacityLabel = usageBlocked ? 'effective weekly capacity' : degraded || health === 'unhealthy' ? 'last known weekly capacity' : 'weekly capacity'
+      const capacityLabel = usageBlocked ? 'effective weekly capacity' : quotaIsLastKnown ? 'last known weekly capacity' : 'weekly capacity'
       return <tr key={account.id}>
         <td data-label="Account"><button className="account-detail-button" type="button" aria-label={`View supported models for ${account.display_name}`} onClick={() => onModels(account)}><span className="account-detail-button__title"><strong>{account.display_name}</strong><ChevronIcon /></span><small>{account.credential_type === 'api_key' ? 'OpenAI-compatible · API key' : `${account.email || 'Email unavailable'} · Codex subscription`}</small></button></td>
         <td data-label="Availability"><div className="account-availability"><span className={`status ${unavailable ? `status--${effectiveStatus}` : `status--health-${healthStatus}`}`}><i />{availabilityLabel}</span><small>{routingLabel}</small>{account.last_health_error_code ? <small className="health-error">{account.last_health_error_code.replaceAll('_', ' ')}</small> : null}</div></td>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -27,6 +27,8 @@ export interface ProviderAccount {
     five_hour?: QuotaWindow
     weekly?: QuotaWindow
   } | null
+  quota_checked_at?: string | null
+  last_quota_error_code?: string | null
   last_success_at?: string | null
   last_failure_at?: string | null
 }


### PR DESCRIPTION
## Summary
- keep scheduled quota probes from being postponed by successful traffic
- track quota refresh timestamps and errors independently from request health
- label cached quota as last known until a quota refresh succeeds

## Testing
- make test build
- PostgreSQL 17 store integration tests