### PR TITLE
Fix WebSocket quota failover

### DIFF
--- a/internal/gateway/responses_ws.go
+++ b/internal/gateway/responses_ws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -31,20 +32,21 @@ const (
 )
 
 type responsesWSSession struct {
-	hub           *responsesWSHub
-	conn          *websocket.Conn
-	ctx           context.Context
-	cancel        context.CancelFunc
-	keyDigest     []byte
-	keyID         string
-	poolID        string
-	headers       http.Header
-	account       domain.ProviderAccount
-	upstream      *websocket.Conn
-	upstreamModel string
-	native        bool
-	pinned        bool
-	lastActive    atomic.Int64
+	hub             *responsesWSHub
+	conn            *websocket.Conn
+	ctx             context.Context
+	cancel          context.CancelFunc
+	keyDigest       []byte
+	keyID           string
+	poolID          string
+	headers         http.Header
+	account         domain.ProviderAccount
+	upstream        *websocket.Conn
+	upstreamModel   string
+	native          bool
+	pinned          bool
+	nativeSwitching bool
+	lastActive      atomic.Int64
 
 	mu        sync.Mutex
 	writeMu   sync.Mutex
@@ -64,15 +66,18 @@ type responsesWSStream struct {
 }
 
 type responsesWSTurn struct {
-	streamID  string
-	accountID string
-	model     string
-	payload   []byte
-	response  string
-	input     int64
-	output    int64
-	terminal  string
-	finished  bool
+	streamID     string
+	accountID    string
+	model        string
+	payload      []byte
+	raw          []byte
+	response     string
+	input        int64
+	output       int64
+	terminal     string
+	continuation bool
+	forwarded    bool
+	finished     bool
 }
 
 type responsesWSRequest struct {
@@ -223,8 +228,12 @@ func (s *responsesWSSession) ensurePinned(request responsesWSRequest, route doma
 	s.mu.Lock()
 	if s.pinned {
 		native := s.native
+		switching := s.nativeSwitching
 		upstreamModel := s.upstreamModel
 		s.mu.Unlock()
+		if switching {
+			return false, false, &gatewayError{http.StatusServiceUnavailable, "provider account failover is in progress", "provider_error"}
+		}
 		if native && request.Model != upstreamModel {
 			return false, false, &gatewayError{http.StatusConflict, "model changed; reconnect to create a new upstream WebSocket", "subpool_websocket_model_changed"}
 		}
@@ -461,6 +470,10 @@ func (s *responsesWSSession) reserveTurn(request responsesWSRequest, payload []b
 		s.mu.Unlock()
 		return nil, &gatewayError{http.StatusServiceUnavailable, "WebSocket session is closing", "server_error"}
 	}
+	if s.nativeSwitching {
+		s.mu.Unlock()
+		return nil, &gatewayError{http.StatusServiceUnavailable, "provider account failover is in progress", "provider_error"}
+	}
 	if s.pending >= responsesWSMaxTurnsPerConnection {
 		s.mu.Unlock()
 		return nil, &gatewayError{http.StatusTooManyRequests, "connection turn capacity exceeded", "subpool_capacity_exceeded"}
@@ -476,12 +489,20 @@ func (s *responsesWSSession) reserveTurn(request responsesWSRequest, payload []b
 	if !s.hub.reserveAccountTurn(accountID) {
 		return nil, &gatewayError{http.StatusServiceUnavailable, "account turn capacity exceeded", "subpool_capacity_exceeded"}
 	}
-	turn := &responsesWSTurn{streamID: streamID, accountID: accountID, model: request.Model, payload: payload}
+	turn := &responsesWSTurn{
+		streamID: streamID, accountID: accountID, model: request.Model, payload: payload,
+		raw: append([]byte(nil), request.raw...), continuation: request.PreviousResponseID != "",
+	}
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
 		s.hub.releaseAccountTurn(accountID)
 		return nil, &gatewayError{http.StatusServiceUnavailable, "WebSocket session is closing", "server_error"}
+	}
+	if s.nativeSwitching {
+		s.mu.Unlock()
+		s.hub.releaseAccountTurn(accountID)
+		return nil, &gatewayError{http.StatusServiceUnavailable, "provider account failover is in progress", "provider_error"}
 	}
 	if request.StreamID != nil {
 		s.named[streamID] = struct{}{}
@@ -529,6 +550,10 @@ func (s *responsesWSSession) readUpstream() {
 		}
 		event := parseResponsesWSEvent(payload)
 		turn := s.currentTurn(event.StreamID)
+		limitKind := classifyResponsesWSLimitEvent(payload)
+		if limitKind != responsesWSLimitNone && s.retryNativeLimitedTurn(turn, upstream, limitKind) {
+			continue
+		}
 		if turn != nil {
 			s.observeTurn(turn, payload, event.Type)
 		}
@@ -539,7 +564,105 @@ func (s *responsesWSSession) readUpstream() {
 		if turn != nil && terminalResponsesWSEvent(event.Type) {
 			s.finishTurn(turn)
 		}
+		if limitKind != responsesWSLimitNone {
+			s.close(websocket.StatusServiceRestart, "provider account limited")
+			return
+		}
 	}
+}
+
+func (s *responsesWSSession) retryNativeLimitedTurn(turn *responsesWSTurn, failedUpstream *websocket.Conn, limitKind responsesWSLimitKind) bool {
+	s.hub.upstreamFailures.Add(1)
+	s.mu.Lock()
+	failedAccount := s.account
+	ownsSwitch := s.native && s.upstream == failedUpstream && !s.nativeSwitching
+	retrySafe := ownsSwitch && turn != nil && !turn.finished && !turn.continuation && !turn.forwarded && s.pending == 1
+	if ownsSwitch {
+		s.nativeSwitching = true
+	}
+	s.mu.Unlock()
+
+	slog.Warn("provider WebSocket limit received", "account_id", failedAccount.ID, "api_key_id", s.keyID, "limit_kind", limitKind)
+	if limitKind == responsesWSLimitQuota {
+		_ = s.hub.server.store.SetProviderUsageAllowed(s.ctx, failedAccount.ID, false)
+	} else {
+		retryAt := s.hub.server.now().Add(time.Minute)
+		_ = s.hub.server.store.UpdateProviderStatus(s.ctx, failedAccount.ID, domain.AccountCoolingDown, &retryAt)
+	}
+	attempted := []string{failedAccount.ID}
+	next, err := s.hub.server.store.ReassignAPIKey(s.ctx, s.keyID, s.poolID, attempted)
+	if err != nil || !retrySafe {
+		return false
+	}
+
+	for len(attempted) < maxProviderAttempts {
+		attempted = append(attempted, next.ID)
+		if next.Provider == domain.ProviderOpenAICompatible {
+			break
+		}
+		conn, account, retry, requestErr := s.dialCodex(next, turn.model)
+		if requestErr == nil {
+			installationID, identityErr := codex.InstallationID(account.ID)
+			payload, payloadErr := normalizeCodexWebSocketRequest(turn.raw, installationID, account.FastModeEnabled)
+			if identityErr != nil || payloadErr != nil {
+				_ = conn.CloseNow()
+				s.hub.server.recordHealthFailure(s.ctx, account.ID, "websocket_request_normalization_failed")
+			} else if !s.hub.reserveAccountTurn(account.ID) {
+				_ = conn.CloseNow()
+			} else {
+				if !s.transferNativeAccount(turn, failedUpstream, conn, account) {
+					s.hub.releaseAccountTurn(account.ID)
+					_ = conn.CloseNow()
+					return false
+				}
+				writeCtx, cancel := context.WithTimeout(s.ctx, responsesWSWriteTimeout)
+				writeErr := conn.Write(writeCtx, websocket.MessageText, payload)
+				cancel()
+				if writeErr == nil {
+					s.finishNativeSwitch()
+					_ = failedUpstream.CloseNow()
+					slog.Info("provider WebSocket turn failed over", "from_account_id", failedAccount.ID, "to_account_id", account.ID, "api_key_id", s.keyID)
+					return true
+				}
+				_ = failedUpstream.CloseNow()
+				_ = conn.CloseNow()
+				s.hub.upstreamFailures.Add(1)
+				s.hub.server.recordHealthFailure(s.ctx, account.ID, "websocket_write_failed")
+				s.sendError(turn.streamID, "provider_error", "provider WebSocket failover failed")
+				s.close(websocket.StatusInternalError, "upstream write failed")
+				return true
+			}
+		}
+		if requestErr != nil && !retry || len(attempted) >= maxProviderAttempts {
+			break
+		}
+		next, err = s.hub.server.store.ReassignAPIKey(s.ctx, s.keyID, s.poolID, attempted)
+		if err != nil {
+			break
+		}
+	}
+	return false
+}
+
+func (s *responsesWSSession) transferNativeAccount(turn *responsesWSTurn, failed, replacement *websocket.Conn, account domain.ProviderAccount) bool {
+	s.mu.Lock()
+	if s.closed || !s.native || !s.nativeSwitching || s.upstream != failed || turn.finished || turn.forwarded || s.pending != 1 {
+		s.mu.Unlock()
+		return false
+	}
+	previousID := turn.accountID
+	s.account = account
+	s.upstream = replacement
+	turn.accountID = account.ID
+	s.mu.Unlock()
+	s.hub.releaseAccountTurn(previousID)
+	return true
+}
+
+func (s *responsesWSSession) finishNativeSwitch() {
+	s.mu.Lock()
+	s.nativeSwitching = false
+	s.mu.Unlock()
 }
 
 func (s *responsesWSSession) startInitialBridge(turn *responsesWSTurn, route domain.KeyRoute, canFailover bool) {

--- a/internal/gateway/responses_ws_protocol.go
+++ b/internal/gateway/responses_ws_protocol.go
@@ -13,6 +13,14 @@ import (
 
 const responsesWSMaxStreamIDBytes = 256
 
+type responsesWSLimitKind uint8
+
+const (
+	responsesWSLimitNone responsesWSLimitKind = iota
+	responsesWSLimitTemporary
+	responsesWSLimitQuota
+)
+
 func parseResponsesWSRequest(payload []byte) (responsesWSRequest, *gatewayError) {
 	trimmed := bytes.TrimSpace(payload)
 	if len(trimmed) == 0 || len(trimmed) > maxRequestBody {
@@ -94,6 +102,46 @@ func parseResponsesWSEvent(payload []byte) responsesWSEvent {
 	var event responsesWSEvent
 	_ = json.Unmarshal(payload, &event)
 	return event
+}
+
+func classifyResponsesWSLimitEvent(payload []byte) responsesWSLimitKind {
+	var event struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Response struct {
+			Error struct {
+				Type    string `json:"type"`
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"response"`
+	}
+	if json.Unmarshal(payload, &event) != nil || (event.Type != "error" && event.Type != "response.failed") {
+		return responsesWSLimitNone
+	}
+	message := strings.ToLower(event.Error.Message + " " + event.Response.Error.Message)
+	for _, phrase := range []string{"hit your usage limit", "reached your usage limit", "usage limit reached", "usage limit has been reached", "quota exceeded", "insufficient quota"} {
+		if strings.Contains(message, phrase) {
+			return responsesWSLimitQuota
+		}
+	}
+	for _, signal := range []string{event.Error.Type, event.Error.Code, event.Response.Error.Type, event.Response.Error.Code} {
+		normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(signal, "-", "_"), " ", "_"))
+		if strings.Contains(normalized, "usage_limit") || strings.Contains(normalized, "quota") {
+			return responsesWSLimitQuota
+		}
+		if strings.Contains(normalized, "rate_limit") {
+			return responsesWSLimitTemporary
+		}
+	}
+	if strings.Contains(message, "rate limit exceeded") {
+		return responsesWSLimitTemporary
+	}
+	return responsesWSLimitNone
 }
 
 func terminalResponsesWSEvent(eventType string) bool {
@@ -205,6 +253,7 @@ func (s *responsesWSSession) observeTurn(turn *responsesWSTurn, payload []byte, 
 	if turn == nil || turn.finished {
 		return
 	}
+	turn.forwarded = true
 	if responseID := responseIDFromEvent(payload); responseID != "" {
 		turn.response = responseID
 	}

--- a/internal/gateway/responses_ws_test.go
+++ b/internal/gateway/responses_ws_test.go
@@ -260,6 +260,63 @@ func TestResponsesWebSocketNativeCodex(t *testing.T) {
 	}
 }
 
+func TestResponsesWebSocketNativeCodexFailsOverUsageLimit(t *testing.T) {
+	upstreamPayloads := make(chan []byte, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		messageType, payload, err := conn.Read(r.Context())
+		if err != nil || messageType != websocket.MessageText {
+			return
+		}
+		upstreamPayloads <- payload
+		if r.Header.Get("Authorization") == "Bearer old-token" {
+			_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"error","error":{"type":"usage_limit_reached","code":"usage_limit_reached","message":"Usage limit reached"}}`))
+			return
+		}
+		_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"response.completed","response":{"id":"resp-failed-over","model":"gpt-test","usage":{}}}`))
+	}))
+	defer upstream.Close()
+
+	server, st, _, plain := newTestServer(t)
+	st.reassigned = accountWithCipher(t, server.cipher.(*credential.Cipher), "account-2", "new-token")
+	server.WithResponsesWebSocket(true, false, upstream.URL)
+	client, cleanup := dialResponsesWSTestServer(t, server, plain)
+	defer cleanup()
+
+	writeResponsesWSMessage(t, client, `{"type":"response.create","model":"gpt-test","input":"hello"}`)
+	if event := readResponsesWSMessage(t, client); event["type"] != "response.completed" {
+		t.Fatalf("event = %#v", event)
+	}
+	if len(st.availabilityUpdates) != 1 || st.availabilityUpdates[0].accountID != st.route.Account.ID || st.availabilityUpdates[0].allowed {
+		t.Fatalf("availability updates = %#v", st.availabilityUpdates)
+	}
+	if len(st.reassignExcludes) != 1 || len(st.reassignExcludes[0]) != 1 || st.reassignExcludes[0][0] != st.route.Account.ID {
+		t.Fatalf("reassign excludes = %#v", st.reassignExcludes)
+	}
+	for index := 0; index < 2; index++ {
+		select {
+		case payload := <-upstreamPayloads:
+			if index == 1 {
+				var body map[string]any
+				if err := json.Unmarshal(payload, &body); err != nil {
+					t.Fatal(err)
+				}
+				metadata, _ := body["client_metadata"].(map[string]any)
+				installationID, _ := codex.InstallationID(st.reassigned.ID)
+				if metadata["x-codex-installation-id"] != installationID {
+					t.Fatalf("replayed payload = %s", payload)
+				}
+			}
+		case <-time.After(time.Second):
+			t.Fatal("native request was not replayed")
+		}
+	}
+}
+
 func TestResponsesWebSocketNativeCodexClosesWhenModelChanges(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
@@ -317,6 +374,38 @@ func TestParseResponsesWSRequestValidatesStreamID(t *testing.T) {
 	payload, _ := json.Marshal(map[string]any{"type": "response.create", "stream_id": valid})
 	if _, requestErr := parseResponsesWSRequest(payload); requestErr != nil {
 		t.Fatalf("valid stream_id was rejected: %#v", requestErr)
+	}
+}
+
+func TestClassifyResponsesWSLimitEvent(t *testing.T) {
+	for _, payload := range []string{
+		`{"type":"error","error":{"code":"usage_limit_reached"}}`,
+		`{"type":"error","error":{"message":"You have hit your usage limit. Please try again later."}}`,
+	} {
+		if classifyResponsesWSLimitEvent([]byte(payload)) != responsesWSLimitQuota {
+			t.Fatalf("usage limit event was not recognized: %s", payload)
+		}
+	}
+	if classifyResponsesWSLimitEvent([]byte(`{"type":"response.failed","response":{"error":{"type":"rate_limit_exceeded"}}}`)) != responsesWSLimitTemporary {
+		t.Fatal("temporary rate limit was not recognized")
+	}
+	if classifyResponsesWSLimitEvent([]byte(`{"type":"error","error":{"code":"invalid_request_error","message":"Invalid input"}}`)) != responsesWSLimitNone {
+		t.Fatal("invalid request was classified as a usage limit")
+	}
+}
+
+func TestResponsesWebSocketRejectsTurnDuringNativeFailover(t *testing.T) {
+	server, st, _, _ := newTestServer(t)
+	session := &responsesWSSession{
+		hub: server.responsesWS, ctx: context.Background(), account: st.route.Account,
+		native: true, nativeSwitching: true, streams: make(map[string]*responsesWSStream), named: make(map[string]struct{}),
+	}
+	request, requestErr := parseResponsesWSRequest([]byte(`{"type":"response.create","model":"gpt-test","input":"hello"}`))
+	if requestErr != nil {
+		t.Fatal(requestErr)
+	}
+	if _, reserveErr := session.reserveTurn(request, request.raw); reserveErr == nil || reserveErr.code != "provider_error" {
+		t.Fatalf("reserve error = %#v", reserveErr)
 	}
 }
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -534,6 +534,12 @@ func accountHealthy(account domain.ProviderAccount, now time.Time) bool {
 	if account.HealthStatus == domain.HealthUnhealthy {
 		return false
 	}
+	if len(account.QuotaSnapshot) > 0 {
+		var quota codex.UsageSnapshot
+		if json.Unmarshal(account.QuotaSnapshot, &quota) == nil && !quota.AllowsUsageAt(now) {
+			return false
+		}
+	}
 	switch account.Status {
 	case domain.AccountActive:
 		return true

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -42,6 +42,12 @@ type fakeStore struct {
 	usageCommitUncertain    bool
 	usageEvents             map[string]struct{}
 	healthFailureCodes      []string
+	availabilityUpdates     []providerAvailabilityUpdate
+}
+
+type providerAvailabilityUpdate struct {
+	accountID string
+	allowed   bool
 }
 
 func (f *fakeStore) ResolveAPIKey(context.Context, []byte) (domain.KeyRoute, error) {
@@ -112,6 +118,10 @@ func (f *fakeStore) AddUsage(_ context.Context, _ string, eventHash []byte, _ st
 }
 func (f *fakeStore) UpdateProviderStatus(_ context.Context, _ string, status string, _ *time.Time) error {
 	f.status = append(f.status, status)
+	return nil
+}
+func (f *fakeStore) SetProviderUsageAllowed(_ context.Context, accountID string, allowed bool) error {
+	f.availabilityUpdates = append(f.availabilityUpdates, providerAvailabilityUpdate{accountID: accountID, allowed: allowed})
 	return nil
 }
 func (f *fakeStore) RecordProviderHealthFailure(_ context.Context, _ string, code string, _ time.Time, _ time.Time) error {
@@ -772,6 +782,26 @@ func compatibleAccountWithCipher(t *testing.T, cipher *credential.Cipher, id str
 }
 func sseResponse(status int, body string) *http.Response {
 	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"text/event-stream"}, "Retry-After": []string{"1"}}, Body: io.NopCloser(strings.NewReader(body))}
+}
+
+func TestAccountHealthyRejectsFullUnresetQuotaWindow(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	allowed := true
+	quota, _ := json.Marshal(codex.UsageSnapshot{
+		UsageAllowed: &allowed,
+		Weekly:       &codex.UsageWindow{UsedPercent: 100, ResetAt: now.Add(time.Hour).Unix()},
+	})
+	account := domain.ProviderAccount{Status: domain.AccountActive, HealthStatus: domain.HealthHealthy, QuotaSnapshot: quota}
+	if accountHealthy(account, now) {
+		t.Fatal("full quota window was considered healthy")
+	}
+	account.QuotaSnapshot, _ = json.Marshal(codex.UsageSnapshot{
+		UsageAllowed: &allowed,
+		Weekly:       &codex.UsageWindow{UsedPercent: 100, ResetAt: now.Add(-time.Hour).Unix()},
+	})
+	if !accountHealthy(account, now) {
+		t.Fatal("reset quota window was considered unavailable")
+	}
 }
 func serveGateway(t *testing.T, server *Server, key, path, body string) *httptest.ResponseRecorder {
 	t.Helper()

--- a/internal/provider/codex/appserver.go
+++ b/internal/provider/codex/appserver.go
@@ -317,6 +317,8 @@ func normalizeAppServerRateLimits(limits appServerRateLimits) *UsageSnapshot {
 		snapshot.markUsageBlocked(*limits.RateLimitReachedType)
 	} else if limits.SpendControlReached != nil && *limits.SpendControlReached {
 		snapshot.markUsageBlocked("spend_control_reached")
+	} else if (snapshot.FiveHour != nil && snapshot.FiveHour.UsedPercent >= 100) || (snapshot.Weekly != nil && snapshot.Weekly.UsedPercent >= 100) {
+		snapshot.markUsageBlocked("rate_limit_reached")
 	}
 	return snapshot
 }

--- a/internal/provider/codex/appserver_test.go
+++ b/internal/provider/codex/appserver_test.go
@@ -49,6 +49,16 @@ func TestAppServerReadsAndConsumesResetCredits(t *testing.T) {
 	}
 }
 
+func TestNormalizeAppServerRateLimitsBlocksFullWindow(t *testing.T) {
+	weeklyMinutes := int64(7 * 24 * 60)
+	snapshot := normalizeAppServerRateLimits(appServerRateLimits{
+		Secondary: &appServerRateLimitWindow{UsedPercent: 100, WindowDurationMins: &weeklyMinutes},
+	})
+	if snapshot == nil || snapshot.UsageAllowed == nil || *snapshot.UsageAllowed || snapshot.LimitReason != "rate_limit_reached" {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
 func TestAppServerPreservesSuccessfulResetWhenSnapshotRefreshFails(t *testing.T) {
 	executable := filepath.Join(t.TempDir(), "codex-test")
 	wrapper := fmt.Sprintf("#!/bin/sh\nSUBPOOL_CODEX_HELPER=1 SUBPOOL_CODEX_FAIL_POST_RESET_READ=1 exec %q -test.run=TestCodexAppServerHelperProcess -- \"$@\"\n", os.Args[0])

--- a/internal/provider/codex/usage.go
+++ b/internal/provider/codex/usage.go
@@ -1,6 +1,9 @@
 package codex
 
-import "math"
+import (
+	"math"
+	"time"
+)
 
 type UsageWindow struct {
 	UsedPercent      float64 `json:"used_percent"`
@@ -21,6 +24,20 @@ func (s *UsageSnapshot) markUsageBlocked(reason string) {
 	allowed := false
 	s.UsageAllowed = &allowed
 	s.LimitReason = reason
+}
+
+func (s UsageSnapshot) AllowsUsageAt(now time.Time) bool {
+	if s.UsageAllowed != nil && !*s.UsageAllowed {
+		return false
+	}
+	return !usageWindowBlocked(s.FiveHour, now) && !usageWindowBlocked(s.Weekly, now)
+}
+
+func usageWindowBlocked(window *UsageWindow, now time.Time) bool {
+	if window == nil || window.UsedPercent < 100 {
+		return false
+	}
+	return window.ResetAt <= 0 || now.Unix() < window.ResetAt
 }
 
 func normalizeUsageWindow(usedPercent float64, windowSeconds, resetAt int64) *UsageWindow {


### PR DESCRIPTION
## Summary
- fail over native Responses WebSocket turns when an upstream account reaches its usage limit
- distinguish quota exhaustion from temporary rate limiting
- reject new turns while account failover is in progress
- treat fully consumed quota windows as unavailable even when the upstream availability flag is stale

## Tests
- `go test ./...`
- `npm test`
- `npm run build`
- `docker build -t subpool:websocket-quota-failover .`